### PR TITLE
Make split_at_time a no-op when time falls inside a gap

### DIFF
--- a/tellers-timeline-core/src/track_methods/track_item_split.rs
+++ b/tellers-timeline-core/src/track_methods/track_item_split.rs
@@ -47,48 +47,8 @@ impl Track {
                 self.items.insert(item_index, crate::Item::Clip(left_clip));
                 self.items.insert(item_index + 1, crate::Item::Clip(clip));
             }
-            crate::Item::Gap(mut gap) => {
-                let total = gap.source_range.duration.value.max(0.0);
-                if local_offset >= total - EPS {
-                    // Nothing to split, put the original back
-                    self.items.insert(item_index, crate::Item::Gap(gap));
-                    return;
-                }
-
-                let left_duration = local_offset.max(0.0);
-                let right_duration = (total - local_offset).max(0.0);
-
-                let left_gap = crate::types::Gap {
-                    otio_schema: gap.otio_schema.clone(),
-                    name: gap.name.clone(),
-                    source_range: crate::types::TimeRange {
-                        otio_schema: gap.source_range.otio_schema.clone(),
-                        duration: crate::types::RationalTime {
-                            otio_schema: gap.source_range.duration.otio_schema.clone(),
-                            rate: gap.source_range.duration.rate,
-                            value: left_duration,
-                        },
-                        start_time: crate::types::RationalTime {
-                            otio_schema: gap.source_range.start_time.otio_schema.clone(),
-                            rate: gap.source_range.start_time.rate,
-                            value: gap.source_range.start_time.value,
-                        },
-                    },
-                    metadata: gap.metadata.clone(),
-                    effects: gap.effects.clone(),
-                };
-
-                gap.source_range.duration.value = right_duration;
-                gap.source_range.start_time.value += left_duration;
-
-                // Ensure the right-hand piece receives a fresh unique id
-                crate::metadata::IdMetadataExt::set_id(
-                    &mut gap,
-                    Some(crate::types::gen_hex_id_12()),
-                );
-
-                self.items.insert(item_index, crate::Item::Gap(left_gap));
-                self.items.insert(item_index + 1, crate::Item::Gap(gap));
+            crate::Item::Gap(gap) => {
+                self.items.insert(item_index, crate::Item::Gap(gap));
             }
         }
     }

--- a/tellers-timeline-core/tests/split.rs
+++ b/tellers-timeline-core/tests/split.rs
@@ -58,19 +58,16 @@ fn split_clip_basic() {
 }
 
 #[test]
-fn split_gap_basic() {
+fn split_gap_is_noop() {
     let mut track = Track::default();
     track.append(Item::Gap(Gap::make_gap(5.0)));
 
     track.split_at_time(2.0);
 
-    assert_eq!(track.items.len(), 2);
-    match (&track.items[0], &track.items[1]) {
-        (Item::Gap(g0), Item::Gap(g1)) => {
-            assert_eq!(g0.source_range.duration.value, 2.0);
-            assert_eq!(g1.source_range.duration.value, 3.0);
-        }
-        _ => panic!("expected two gaps after split"),
+    assert_eq!(track.items.len(), 1);
+    match &track.items[0] {
+        Item::Gap(g) => assert_eq!(g.source_range.duration.value, 5.0),
+        _ => panic!("expected gap to be unchanged"),
     }
 }
 


### PR DESCRIPTION
## Summary

- Splitting at a time that falls inside a gap is now a no-op (gap is left unchanged)
- Previously the gap was split into two gaps, which could cause unexpected behavior
- Updated test to verify the no-op behavior

## Test plan

- [ ] `cargo test --package tellers-timeline-core` passes
- [ ] `split_gap_is_noop` confirms gap is unchanged after split

🤖 Generated with [Claude Code](https://claude.com/claude-code)