### PR TITLE
Align stack linked edits with boundary gaps

### DIFF
--- a/bindings/python/tests/test_linked.py
+++ b/bindings/python/tests/test_linked.py
@@ -1115,8 +1115,10 @@ def test_move_unlinked_item_without_gap_pulls_later_linked_assets():
         "unlinked",
     ]
     assert all(item.is_clip() for item in stack.tracks()[video_track].items())
-    assert len(stack.tracks()[audio_track].items()) == 1
-    assert stack.tracks()[audio_track].items()[0].is_clip()
+    audio_items = stack.tracks()[audio_track].items()
+    assert len(audio_items) == 2
+    assert audio_items[audio_index].is_clip()
+    assert any(item.is_gap() and item.duration() == 1.0 for item in audio_items)
 
 
 def test_move_item_at_index_moves_linked_group():

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -2042,7 +2042,7 @@ impl Stack {
     }
 }
 
-fn range_is_gap_backed(track: &Track, start: Seconds, end: Seconds) -> bool {
+pub(super) fn range_is_gap_backed(track: &Track, start: Seconds, end: Seconds) -> bool {
     if start < -EPS || end < start - EPS {
         return false;
     }
@@ -2109,7 +2109,7 @@ fn range_has_blocking_clip(
     false
 }
 
-fn split_gap_boundary(track: &mut Track, time: Seconds) {
+pub(super) fn split_gap_boundary(track: &mut Track, time: Seconds) {
     let Some(index) = track.get_item_at_time(time) else {
         return;
     };

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -338,6 +338,80 @@ impl Stack {
         Some(insert_at)
     }
 
+    fn find_or_create_move_audio_track(
+        &mut self,
+        primary_track_index: usize,
+        dest_time: Seconds,
+        duration: Seconds,
+        created_track_indices: &mut Vec<usize>,
+        used_audio_indices: &[usize],
+    ) -> Option<usize> {
+        let end_time = dest_time + duration;
+        match self.children.get(primary_track_index)?.kind {
+            TrackKind::Video => {
+                let mut audio_start = primary_track_index;
+                while audio_start > 0 && self.children[audio_start - 1].kind == TrackKind::Audio {
+                    audio_start -= 1;
+                }
+
+                for audio_index in (audio_start..primary_track_index).rev() {
+                    if used_audio_indices.contains(&audio_index) {
+                        continue;
+                    }
+                    if range_is_gap_backed(&self.children[audio_index], dest_time, end_time) {
+                        return Some(audio_index);
+                    }
+                }
+
+                let insert_at = if audio_start < primary_track_index {
+                    audio_start
+                } else {
+                    primary_track_index
+                };
+                self.children
+                    .insert(insert_at, self.new_numbered_track(TrackKind::Audio));
+                created_track_indices.push(insert_at);
+                Some(insert_at)
+            }
+            TrackKind::Audio => {
+                let mut audio_start = primary_track_index;
+                while audio_start > 0 && self.children[audio_start - 1].kind == TrackKind::Audio {
+                    audio_start -= 1;
+                }
+                let mut audio_end = primary_track_index + 1;
+                while audio_end < self.children.len()
+                    && self.children[audio_end].kind == TrackKind::Audio
+                {
+                    audio_end += 1;
+                }
+
+                let mut candidates: Vec<_> = (audio_start..audio_end)
+                    .filter(|track_index| {
+                        *track_index != primary_track_index
+                            && !used_audio_indices.contains(track_index)
+                            && range_is_gap_backed(
+                                &self.children[*track_index],
+                                dest_time,
+                                end_time,
+                            )
+                    })
+                    .collect();
+                candidates.sort_by_key(|track_index| {
+                    (track_index.abs_diff(primary_track_index), *track_index)
+                });
+                if let Some(track_index) = candidates.into_iter().next() {
+                    return Some(track_index);
+                }
+
+                self.children
+                    .insert(audio_end, self.new_numbered_track(TrackKind::Audio));
+                created_track_indices.push(audio_end);
+                Some(audio_end)
+            }
+            TrackKind::Other => None,
+        }
+    }
+
     fn find_or_create_video_track_for_audio(
         &mut self,
         audio_track_index: usize,
@@ -1724,6 +1798,7 @@ impl Stack {
             return false;
         };
         let selected_item = &items_to_move[selected_position];
+        let selected_source_track_index = selected_item.track_index;
         let Some(selected_id) = selected_item.item.get_id() else {
             return false;
         };
@@ -1795,24 +1870,29 @@ impl Stack {
             TrackKind::Other => {}
         }
 
-        for (position, move_item) in items_to_move.into_iter().enumerate() {
-            if position == selected_position {
-                continue;
-            }
+        let mut companion_items: Vec<_> = items_to_move
+            .into_iter()
+            .enumerate()
+            .filter(|(position, _)| *position != selected_position)
+            .collect();
+        companion_items.sort_by_key(|(_, move_item)| {
+            (
+                move_item.track_index.abs_diff(selected_source_track_index),
+                move_item.track_index,
+            )
+        });
+
+        for (_, move_item) in companion_items {
 
             match move_item.track_kind {
                 TrackKind::Audio => {
                     let track_count_before = self.children.len();
-                    let Some(track_index) = self.find_or_create_audio_track(
+                    let Some(track_index) = self.find_or_create_move_audio_track(
                         dest_track_index,
                         moved_start,
                         moved_duration,
                         &mut created_track_indices,
                         &used_audio_track_indices,
-                        &used_audio_boundary_indices,
-                        Some(link_group_id),
-                        true,
-                        overlap_policy,
                     ) else {
                         *self = backup;
                         return false;

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -51,6 +51,7 @@ struct LinkedInputs {
 struct LinkedMoveItem {
     track_index: usize,
     item_index: usize,
+    track_kind: TrackKind,
     item: Item,
     is_selected: bool,
 }
@@ -83,6 +84,27 @@ enum LinkedMovePlacement {
     Index {
         dest_index: usize,
     },
+}
+
+fn shift_track_index_after_insert(track_index: &mut usize, inserted_track_index: usize) {
+    if inserted_track_index <= *track_index {
+        *track_index += 1;
+    }
+}
+
+fn shift_track_indices_after_insert(track_indices: &mut [usize], inserted_track_index: usize) {
+    for track_index in track_indices {
+        shift_track_index_after_insert(track_index, inserted_track_index);
+    }
+}
+
+fn shift_move_placements_after_insert(
+    placements: &mut [(usize, Item, bool)],
+    inserted_track_index: usize,
+) {
+    for (track_index, _, _) in placements {
+        shift_track_index_after_insert(track_index, inserted_track_index);
+    }
 }
 
 fn clamp_insertion_index(len: usize, index: isize) -> usize {
@@ -735,33 +757,6 @@ impl Stack {
             start = end;
         }
         true
-    }
-
-    fn boundary_track_indices_for_link_groups(
-        &self,
-        link_groups: &[i64],
-        anchor_track_indices: &[usize],
-        excluded_track_indices: &[usize],
-    ) -> Vec<usize> {
-        if link_groups.is_empty() {
-            return Vec::new();
-        }
-
-        let mut track_indices = Vec::new();
-        for anchor_track_index in anchor_track_indices {
-            for track_index in &self
-                .flatten_boundary_for_link_groups(*anchor_track_index, link_groups)
-                .track_indices
-            {
-                if excluded_track_indices.contains(track_index) {
-                    continue;
-                }
-                if !track_indices.contains(track_index) {
-                    track_indices.push(*track_index);
-                }
-            }
-        }
-        track_indices
     }
 
     fn boundary_track_indices_for_anchors(
@@ -1692,6 +1687,7 @@ impl Stack {
 
         let mut items = Vec::new();
         for (track_index, item_index) in targets {
+            let track_kind = self.children.get(track_index)?.kind.clone();
             let item = self
                 .children
                 .get(track_index)?
@@ -1703,6 +1699,7 @@ impl Stack {
             items.push(LinkedMoveItem {
                 track_index,
                 item_index,
+                track_kind,
                 item,
                 is_selected,
             });
@@ -1713,7 +1710,7 @@ impl Stack {
     fn move_linked_items(
         &mut self,
         items_to_move: Vec<LinkedMoveItem>,
-        dest_track_index: usize,
+        mut dest_track_index: usize,
         replace_with_gap: bool,
         overlap_policy: OverlapPolicy,
         placement: LinkedMovePlacement,
@@ -1723,10 +1720,6 @@ impl Stack {
             return false;
         }
 
-        let mut items_to_move = items_to_move;
-        for item in &mut items_to_move {
-            item.item.clamp_to_active_available_range();
-        }
         let Some(selected_position) = items_to_move.iter().position(|item| item.is_selected) else {
             return false;
         };
@@ -1748,23 +1741,6 @@ impl Stack {
         {
             return false;
         }
-
-        let source_track_indices: Vec<_> =
-            items_to_move.iter().map(|item| item.track_index).collect();
-        let mut anchor_track_indices = source_track_indices.clone();
-        anchor_track_indices.push(dest_track_index);
-        let mut boundary_track_indices = self.boundary_track_indices_for_link_groups(
-            &[link_group_id],
-            &anchor_track_indices,
-            &[],
-        );
-        for track_index in anchor_track_indices {
-            if !boundary_track_indices.contains(&track_index) {
-                boundary_track_indices.push(track_index);
-            }
-        }
-        boundary_track_indices.sort_unstable();
-        boundary_track_indices.dedup();
 
         let mut used_ids = self.collect_timeline_ids();
         let mut targets: Vec<_> = items_to_move
@@ -1804,25 +1780,132 @@ impl Stack {
             }
         };
 
-        let mut placements = Vec::new();
-        placements.push((
+        let mut placements = vec![(
             dest_track_index,
             items_to_move[selected_position].item.clone(),
             true,
-        ));
+        )];
+        let mut created_track_indices = Vec::new();
+        let mut used_audio_track_indices = Vec::new();
+        let mut used_audio_boundary_indices = Vec::new();
+        let mut used_video_track_indices = Vec::new();
+        match self.children[dest_track_index].kind {
+            TrackKind::Audio => used_audio_track_indices.push(dest_track_index),
+            TrackKind::Video => used_video_track_indices.push(dest_track_index),
+            TrackKind::Other => {}
+        }
+
         for (position, move_item) in items_to_move.into_iter().enumerate() {
             if position == selected_position {
                 continue;
             }
-            if placements
-                .iter()
-                .any(|(track_index, _, _)| *track_index == move_item.track_index)
-            {
-                *self = backup;
-                return false;
-            };
-            placements.push((move_item.track_index, move_item.item, false));
+
+            match move_item.track_kind {
+                TrackKind::Audio => {
+                    let track_count_before = self.children.len();
+                    let Some(track_index) = self.find_or_create_audio_track(
+                        dest_track_index,
+                        moved_start,
+                        moved_duration,
+                        &mut created_track_indices,
+                        &used_audio_track_indices,
+                        &used_audio_boundary_indices,
+                        Some(link_group_id),
+                        true,
+                        overlap_policy,
+                    ) else {
+                        *self = backup;
+                        return false;
+                    };
+                    let reused_empty_boundary_track = self.children.len() == track_count_before
+                        && track_is_empty_boundary(&self.children[track_index]);
+                    if self.children.len() > track_count_before {
+                        shift_track_index_after_insert(&mut dest_track_index, track_index);
+                        shift_move_placements_after_insert(&mut placements, track_index);
+                        shift_track_indices_after_insert(
+                            &mut used_audio_track_indices,
+                            track_index,
+                        );
+                        shift_track_indices_after_insert(
+                            &mut used_audio_boundary_indices,
+                            track_index,
+                        );
+                        shift_track_indices_after_insert(
+                            &mut used_video_track_indices,
+                            track_index,
+                        );
+                    }
+                    placements.push((track_index, move_item.item, false));
+                    used_audio_track_indices.push(track_index);
+                    if reused_empty_boundary_track {
+                        used_audio_boundary_indices.push(track_index);
+                    }
+                }
+                TrackKind::Video => {
+                    let track_count_before = self.children.len();
+                    let Some(mut track_index) = self.find_or_create_video_track_for_audio(
+                        dest_track_index,
+                        moved_start,
+                        moved_duration,
+                        &mut created_track_indices,
+                        Some(link_group_id),
+                        true,
+                        overlap_policy,
+                    ) else {
+                        *self = backup;
+                        return false;
+                    };
+                    if self.children.len() > track_count_before {
+                        shift_track_index_after_insert(&mut dest_track_index, track_index);
+                        shift_move_placements_after_insert(&mut placements, track_index);
+                        shift_track_indices_after_insert(
+                            &mut used_audio_track_indices,
+                            track_index,
+                        );
+                        shift_track_indices_after_insert(
+                            &mut used_audio_boundary_indices,
+                            track_index,
+                        );
+                        shift_track_indices_after_insert(
+                            &mut used_video_track_indices,
+                            track_index,
+                        );
+                    }
+                    if used_video_track_indices.contains(&track_index) {
+                        let insert_at = track_index;
+                        self.children
+                            .insert(insert_at, self.new_numbered_track(TrackKind::Video));
+                        created_track_indices.push(insert_at);
+                        shift_track_index_after_insert(&mut dest_track_index, insert_at);
+                        shift_move_placements_after_insert(&mut placements, insert_at);
+                        shift_track_indices_after_insert(&mut used_audio_track_indices, insert_at);
+                        shift_track_indices_after_insert(
+                            &mut used_audio_boundary_indices,
+                            insert_at,
+                        );
+                        shift_track_indices_after_insert(&mut used_video_track_indices, insert_at);
+                        track_index = insert_at;
+                    }
+                    placements.push((track_index, move_item.item, false));
+                    used_video_track_indices.push(track_index);
+                }
+                TrackKind::Other => {
+                    *self = backup;
+                    return false;
+                }
+            }
         }
+
+        let mut boundary_track_indices =
+            self.boundary_track_indices_for_anchors(&[link_group_id], &[dest_track_index], &[]);
+        for (track_index, _, _) in &placements {
+            if !boundary_track_indices.contains(track_index) {
+                boundary_track_indices.push(*track_index);
+            }
+        }
+        boundary_track_indices.sort_unstable();
+        boundary_track_indices.dedup();
+
         for track_index in boundary_track_indices {
             if placements
                 .iter()
@@ -1853,12 +1936,20 @@ impl Stack {
                     }
                 }
             } else {
-                self.children[track_index].insert_at_time(
-                    moved_start,
-                    item,
-                    overlap_policy,
-                    InsertPolicy::SplitAndInsert,
-                );
+                let moved_end = moved_start + item.duration().max(0.0);
+                if range_is_gap_backed(&self.children[track_index], moved_start, moved_end) {
+                    if !self.insert_gap_only(track_index, moved_start, item) {
+                        *self = backup;
+                        return false;
+                    }
+                } else {
+                    self.children[track_index].insert_at_time(
+                        moved_start,
+                        item,
+                        overlap_policy,
+                        InsertPolicy::SplitAndInsert,
+                    );
+                }
             }
         }
         if self.get_item(&selected_id).is_none() {
@@ -2000,10 +2091,14 @@ fn item_source_start(item: &Item) -> Seconds {
 fn set_item_source_start(item: &mut Item, source_start_time: Seconds) {
     match item {
         Item::Clip(clip) => {
-            clip.source_range.start_time.set_from_seconds(source_start_time);
+            clip.source_range
+                .start_time
+                .set_from_seconds(source_start_time);
         }
         Item::Gap(gap) => {
-            gap.source_range.start_time.set_from_seconds(source_start_time);
+            gap.source_range
+                .start_time
+                .set_from_seconds(source_start_time);
         }
     }
 }

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -194,17 +194,13 @@ impl Stack {
         let end = start + duration;
 
         if start >= total - EPS {
-            return self
-                .insert_item_at_time(
-                    track_index,
-                    start,
-                    item,
-                    OverlapPolicy::Override,
-                    InsertPolicy::InsertBefore,
-                    None,
-                    None,
-                )
-                .is_some();
+            self.children[track_index].insert_at_time(
+                start,
+                item,
+                OverlapPolicy::Override,
+                InsertPolicy::InsertBefore,
+            );
+            return true;
         }
 
         if !range_is_gap_backed(&self.children[track_index], start, end) {
@@ -215,16 +211,13 @@ impl Stack {
         split_gap_boundary(track, end);
         split_gap_boundary(track, start);
 
-        self.insert_item_at_time(
-            track_index,
+        self.children[track_index].insert_at_time(
             start,
             item,
             OverlapPolicy::Override,
             InsertPolicy::InsertBefore,
-            None,
-            None,
-        )
-        .is_some()
+        );
+        true
     }
 
     fn find_or_create_audio_track(
@@ -1440,6 +1433,7 @@ impl Stack {
                 *self = backup;
                 return false;
             }
+            self.sanitize();
             return true;
         }
         let excluded_ids: HashSet<_> = target_ids.iter().cloned().collect();
@@ -1490,6 +1484,7 @@ impl Stack {
                 *self = backup;
                 return false;
             }
+            self.sanitize();
             return true;
         }
 
@@ -1551,6 +1546,7 @@ impl Stack {
             *self = backup;
             return false;
         }
+        self.sanitize();
         true
     }
 

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -936,6 +936,70 @@ impl Stack {
         self.linked_groups_overlapping_range(track_index, start, affected_duration)
     }
 
+    fn linked_groups_for_insert_at_time_boundary(
+        &self,
+        track_index: usize,
+        dest_time: Seconds,
+        duration: Seconds,
+        overlap_policy: OverlapPolicy,
+        insert_policy: InsertPolicy,
+    ) -> Vec<i64> {
+        let Some(track) = self.children.get(track_index) else {
+            return Vec::new();
+        };
+        let Some(start) = insertion_start_or_end_for_policy(track, dest_time, insert_policy) else {
+            return Vec::new();
+        };
+        let mut groups = self.linked_groups_touched_by_insert_at_time(
+            track_index,
+            dest_time,
+            duration,
+            overlap_policy,
+            insert_policy,
+        );
+        for group in self.linked_groups_adjacent_to_time(track_index, start) {
+            if !groups.contains(&group) {
+                groups.push(group);
+            }
+        }
+        for group in self.linked_groups_adjacent_to_time(track_index, start + duration.max(0.0)) {
+            if !groups.contains(&group) {
+                groups.push(group);
+            }
+        }
+        groups
+    }
+
+    fn linked_groups_for_insert_at_index_boundary(
+        &self,
+        track_index: usize,
+        dest_index: usize,
+        duration: Seconds,
+        overlap_policy: OverlapPolicy,
+    ) -> Vec<i64> {
+        let Some(track) = self.children.get(track_index) else {
+            return Vec::new();
+        };
+        let start = track.start_time_of_item(dest_index.min(track.items.len()));
+        let mut groups = self.linked_groups_touched_by_insert_at_index(
+            track_index,
+            dest_index,
+            duration,
+            overlap_policy,
+        );
+        for group in self.linked_groups_adjacent_to_time(track_index, start) {
+            if !groups.contains(&group) {
+                groups.push(group);
+            }
+        }
+        for group in self.linked_groups_adjacent_to_time(track_index, start + duration.max(0.0)) {
+            if !groups.contains(&group) {
+                groups.push(group);
+            }
+        }
+        groups
+    }
+
     fn sync_changed_link_groups_after_resize(
         &mut self,
         before_states: &HashMap<String, LinkedClipState>,
@@ -1062,15 +1126,15 @@ impl Stack {
         {
             return None;
         }
-        let touched_link_groups = if let Some(dest_index) = dest_index {
-            self.linked_groups_touched_by_insert_at_index(
+        let boundary_link_groups = if let Some(dest_index) = dest_index {
+            self.linked_groups_for_insert_at_index_boundary(
                 dest_track_index,
                 dest_index,
                 modified_duration,
                 overlap_policy,
             )
         } else {
-            self.linked_groups_touched_by_insert_at_time(
+            self.linked_groups_for_insert_at_time_boundary(
                 dest_track_index,
                 dest_time,
                 modified_duration,
@@ -1170,10 +1234,10 @@ impl Stack {
             }
         }
 
-        let boundary_groups = if touched_link_groups.is_empty() && has_linked_clips {
+        let boundary_groups = if boundary_link_groups.is_empty() && has_linked_clips {
             self.linked_groups_adjacent_to_time(primary_track_index, start)
         } else {
-            touched_link_groups.clone()
+            boundary_link_groups.clone()
         };
         let mut boundary_track_indices =
             self.boundary_track_indices_for_anchors(&boundary_groups, &[primary_track_index], &[]);
@@ -1294,10 +1358,18 @@ impl Stack {
                     );
                 }
             } else {
+                let companion_overlap_policy = if matches!(item, Item::Gap(_))
+                    && overlap_policy == OverlapPolicy::Override
+                    && start >= self.children[track_index].total_duration() - EPS
+                {
+                    OverlapPolicy::Push
+                } else {
+                    overlap_policy
+                };
                 self.children[track_index].insert_at_time(
                     start,
                     item,
-                    overlap_policy,
+                    companion_overlap_policy,
                     InsertPolicy::SplitAndInsert,
                 );
             }

--- a/tellers-timeline-core/src/stack_methods/stack_item_insert.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_item_insert.rs
@@ -1,5 +1,5 @@
 use super::InsertItemAtTimeResult;
-use crate::{IdMetadataExt, InsertPolicy, Item, OverlapPolicy, Seconds, Stack};
+use crate::{InsertPolicy, Item, OverlapPolicy, Seconds, Stack};
 
 impl Stack {
     /// Insert an item at a given time into the track at `dest_track_index`.
@@ -39,14 +39,17 @@ impl Stack {
             );
         }
 
-        let inserted_id = item.get_id();
+        let mut item = item;
+        let mut used_ids = self.collect_timeline_ids();
+        let inserted_id = Self::ensure_unique_item_id(&mut item, &mut used_ids);
         self.children[dest_track_index].insert_at_time(
             dest_time,
             item,
             overlap_policy,
             insert_policy,
         );
-        inserted_id.map(InsertItemAtTimeResult::ItemId)
+        self.sanitize();
+        Some(InsertItemAtTimeResult::ItemId(inserted_id))
     }
 
     /// Insert an item at an index into the track with `dest_track_id`.
@@ -89,8 +92,11 @@ impl Stack {
             );
         }
 
-        let inserted_id = item.get_id();
+        let mut item = item;
+        let mut used_ids = self.collect_timeline_ids();
+        let inserted_id = Self::ensure_unique_item_id(&mut item, &mut used_ids);
         self.children[dest_track_index].insert_at_index(dest_index, item, overlap_policy);
-        inserted_id.map(InsertItemAtTimeResult::ItemId)
+        self.sanitize();
+        Some(InsertItemAtTimeResult::ItemId(inserted_id))
     }
 }

--- a/tellers-timeline-core/src/stack_methods/stack_item_insert.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_item_insert.rs
@@ -17,16 +17,15 @@ impl Stack {
         if dest_track_index >= self.children.len() {
             return None;
         }
-        let touches_linked_group = !self
-            .linked_groups_touched_by_insert_at_time(
-                dest_track_index,
-                dest_time,
-                item.duration(),
-                overlap_policy,
-                insert_policy,
-            )
-            .is_empty();
-        if Self::has_linked_inputs(&linked_audio_clips, &linked_video_clip) || touches_linked_group
+        let boundary_link_groups = self.linked_groups_for_insert_at_time_boundary(
+            dest_track_index,
+            dest_time,
+            item.duration(),
+            overlap_policy,
+            insert_policy,
+        );
+        if Self::has_linked_inputs(&linked_audio_clips, &linked_video_clip)
+            || !boundary_link_groups.is_empty()
         {
             return self.insert_linked_item_at_time(
                 dest_track_index,
@@ -69,15 +68,14 @@ impl Stack {
             return None;
         }
 
-        let touches_linked_group = !self
-            .linked_groups_touched_by_insert_at_index(
-                dest_track_index,
-                dest_index,
-                item.duration(),
-                overlap_policy,
-            )
-            .is_empty();
-        if Self::has_linked_inputs(&linked_audio_clips, &linked_video_clip) || touches_linked_group
+        let boundary_link_groups = self.linked_groups_for_insert_at_index_boundary(
+            dest_track_index,
+            dest_index,
+            item.duration(),
+            overlap_policy,
+        );
+        if Self::has_linked_inputs(&linked_audio_clips, &linked_video_clip)
+            || !boundary_link_groups.is_empty()
         {
             return self.insert_linked_item_at_time(
                 dest_track_index,

--- a/tellers-timeline-core/src/stack_methods/stack_item_replace.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_item_replace.rs
@@ -1,5 +1,5 @@
-use super::{resolve_link_group_id, EPS};
-use crate::{Gap, IdMetadataExt, Item, Stack, TrackKind};
+use super::{range_is_gap_backed, resolve_link_group_id, split_gap_boundary, EPS};
+use crate::{Gap, IdMetadataExt, InsertPolicy, Item, OverlapPolicy, Seconds, Stack, Track, TrackKind};
 
 fn shift_track_index_after_insert(track_index: &mut usize, inserted_track_index: usize) {
     if inserted_track_index <= *track_index {
@@ -22,6 +22,34 @@ fn shift_insert_tracks_after_insert(insertions: &mut [(usize, Item)], inserted_t
     }
 }
 
+fn remove_gap_range(track: &mut Track, start: Seconds, end: Seconds) -> bool {
+    if !range_is_gap_backed(track, start, end) {
+        return false;
+    }
+
+    split_gap_boundary(track, end);
+    split_gap_boundary(track, start);
+
+    let mut pos = 0.0;
+    let mut index = 0;
+    while index < track.items.len() {
+        let duration = track.items[index].duration().max(0.0);
+        let item_start = pos;
+        let item_end = pos + duration;
+        if item_start >= start - EPS && item_end <= end + EPS {
+            if !matches!(track.items[index], Item::Gap(_)) {
+                return false;
+            }
+            track.items.remove(index);
+            pos = item_end;
+        } else {
+            pos = item_end;
+            index += 1;
+        }
+    }
+    true
+}
+
 impl Stack {
     pub fn replace_item(
         &mut self,
@@ -37,6 +65,7 @@ impl Stack {
         };
         let selected_start =
             self.children[selected_track_index].start_time_of_item(selected_item_index);
+        let selected_duration = selected_item.duration().max(0.0);
         let selected_link_group = match selected_item {
             Item::Clip(clip) => resolve_link_group_id(&clip.metadata),
             Item::Gap(_) => None,
@@ -121,6 +150,21 @@ impl Stack {
         }
 
         let Some(link_group_id) = link_group else {
+            let mut adjacent_link_groups =
+                self.linked_groups_adjacent_to_time(selected_track_index, selected_start);
+            for link_group in self.linked_groups_adjacent_to_time(
+                selected_track_index,
+                selected_start + selected_duration,
+            ) {
+                if !adjacent_link_groups.contains(&link_group) {
+                    adjacent_link_groups.push(link_group);
+                }
+            }
+            let boundary_track_indices = self.boundary_track_indices_for_anchors(
+                &adjacent_link_groups,
+                &[selected_track_index],
+                &[],
+            );
             for (track_index, item_index, item) in replacements {
                 let Some(track) = self.children.get_mut(track_index) else {
                     *self = backup;
@@ -129,6 +173,40 @@ impl Stack {
                 if !track.replace_item_by_index(item_index, item) {
                     *self = backup;
                     return false;
+                }
+            }
+            if (replacement_duration - selected_duration).abs() > EPS {
+                let mut used_ids = self.collect_timeline_ids();
+                for track_index in boundary_track_indices {
+                    if track_index == selected_track_index {
+                        continue;
+                    }
+                    if replacement_duration > selected_duration + EPS {
+                        let mut gap =
+                            Item::Gap(Gap::make_gap(replacement_duration - selected_duration));
+                        Self::ensure_unique_item_id(&mut gap, &mut used_ids);
+                        let Some(track) = self.children.get_mut(track_index) else {
+                            *self = backup;
+                            return false;
+                        };
+                        track.insert_at_time(
+                            selected_start + selected_duration,
+                            gap,
+                            OverlapPolicy::Push,
+                            InsertPolicy::SplitAndInsert,
+                        );
+                    } else {
+                        let shrink = selected_duration - replacement_duration;
+                        let end = selected_start + selected_duration;
+                        let Some(track) = self.children.get_mut(track_index) else {
+                            *self = backup;
+                            return false;
+                        };
+                        if !remove_gap_range(track, (end - shrink).max(selected_start), end) {
+                            *self = backup;
+                            return false;
+                        }
+                    }
                 }
             }
             self.sanitize();

--- a/tellers-timeline-core/tests/insert.rs
+++ b/tellers-timeline-core/tests/insert.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use tellers_timeline_core::{
-    Clip, InsertPolicy, Item, MediaReference, OverlapPolicy, RationalTime, Seconds, Stack,
-    TimeRange, Track,
+    Clip, IdMetadataExt, InsertItemAtTimeResult, InsertPolicy, Item, MediaReference,
+    OverlapPolicy, RationalTime, Seconds, Stack, TimeRange, Track,
 };
 
 fn make_clip(duration: Seconds, media_start: Seconds) -> Item {
@@ -210,6 +210,52 @@ fn insert_before_after_or_boundary() {
     );
     let track = &stack.children[0];
     assert_eq!(track.items.len(), before_len + 1);
+}
+
+#[test]
+fn insert_plain_item_without_id_returns_assigned_id() {
+    let mut stack = stack_with_items(vec![]);
+
+    let result = stack.insert_item_at_time(
+        0,
+        0.0,
+        make_clip(1.0, 0.0),
+        OverlapPolicy::Push,
+        InsertPolicy::InsertBefore,
+        None,
+        None,
+    );
+
+    let Some(InsertItemAtTimeResult::ItemId(inserted_id)) = result else {
+        panic!("expected inserted id");
+    };
+    assert_eq!(
+        stack.children[0].items[0].get_id().as_deref(),
+        Some(inserted_id.as_str())
+    );
+}
+
+#[test]
+fn insert_plain_item_at_index_without_id_returns_assigned_id() {
+    let mut stack = stack_with_items(vec![make_clip(1.0, 0.0)]);
+    let track_id = stack.children[0].get_id().unwrap();
+
+    let result = stack.insert_item_at_index(
+        &track_id,
+        1,
+        make_clip(1.0, 0.0),
+        OverlapPolicy::Push,
+        None,
+        None,
+    );
+
+    let Some(InsertItemAtTimeResult::ItemId(inserted_id)) = result else {
+        panic!("expected inserted id");
+    };
+    assert_eq!(
+        stack.children[0].items[1].get_id().as_deref(),
+        Some(inserted_id.as_str())
+    );
 }
 
 #[test]

--- a/tellers-timeline-core/tests/linked.rs
+++ b/tellers-timeline-core/tests/linked.rs
@@ -2971,6 +2971,73 @@ fn move_unlinked_item_with_gap_and_split_target_updates_linked_assets() {
 }
 
 #[test]
+fn move_unlinked_item_pushes_full_linked_boundary_with_gap_companions() {
+    let mut video = Track::new(TrackKind::Video, Some("v".to_string()));
+    video.items.push(Item::Clip(clip(1.0, Some("unlinked"))));
+
+    let mut stack = Stack::default();
+    stack.children.push(video);
+    let result = insert_with_audio(
+        &mut stack,
+        0,
+        1.0,
+        clip(2.0, Some("linked-video")),
+        vec![
+            audio_clip(2.0, "file:///linked-a1.wav", None),
+            audio_clip(2.0, "file:///linked-a2.wav", None),
+        ],
+    )
+    .unwrap();
+    let audio_ids: Vec<_> = result
+        .audio_clips
+        .iter()
+        .map(|(id, _)| id.clone())
+        .collect();
+
+    assert!(stack.move_item_at_time(
+        "unlinked",
+        "v",
+        0.0,
+        true,
+        InsertPolicy::SplitAndInsert,
+        OverlapPolicy::Push,
+    ));
+
+    let (video_track_index, video_item_index, moved_item) = stack.get_item("unlinked").unwrap();
+    assert_eq!(
+        stack.children[video_track_index].start_time_of_item(video_item_index),
+        0.0
+    );
+    assert_eq!(moved_item.duration(), 1.0);
+
+    let (linked_video_track_index, linked_video_item_index, linked_video) =
+        stack.get_item("linked-video").unwrap();
+    assert_eq!(
+        stack.children[linked_video_track_index].start_time_of_item(linked_video_item_index),
+        2.0
+    );
+    assert_eq!(link_group_id(linked_video), result.link_group_id);
+
+    for audio_id in &audio_ids {
+        let (audio_track_index, audio_item_index, audio_item) = stack.get_item(audio_id).unwrap();
+        assert_eq!(
+            stack.children[audio_track_index].start_time_of_item(audio_item_index),
+            2.0
+        );
+        assert_eq!(link_group_id(audio_item), result.link_group_id);
+        let spacer_index = stack.children[audio_track_index].get_item_at_time(0.5).unwrap();
+        assert!(matches!(
+            stack.children[audio_track_index].items[spacer_index],
+            Item::Gap(_)
+        ));
+        assert_eq!(
+            stack.children[audio_track_index].items[spacer_index].duration(),
+            1.0
+        );
+    }
+}
+
+#[test]
 fn track_timeline_ids_returns_child_item_ids_in_order() {
     let mut track = Track::new(TrackKind::Video, Some("track".to_string()));
     track.items.push(Item::Clip(clip(1.0, Some("clip-1"))));

--- a/tellers-timeline-core/tests/linked.rs
+++ b/tellers-timeline-core/tests/linked.rs
@@ -2416,6 +2416,70 @@ fn move_item_at_time_moves_linked_group() {
 }
 
 #[test]
+fn move_linked_video_to_new_boundary_creates_audio_track_without_retiming() {
+    let mut stack = Stack::default();
+    stack
+        .children
+        .push(Track::new(TrackKind::Video, Some("source-v".to_string())));
+    let result = insert_with_audio(
+        &mut stack,
+        0,
+        0.0,
+        clip_with_media_range(3.0, 2.0, 0.0, 10.0),
+        vec![audio_clip(3.0, "file:///source-audio.wav", None)],
+    )
+    .unwrap();
+    let audio_id = result.audio_clips[0].0.clone();
+    let (source_audio_track_index, source_audio_item_index, _) = stack.get_item(&audio_id).unwrap();
+    let source_audio_track_id = stack.children[source_audio_track_index].get_id().unwrap();
+    if let Item::Clip(clip) =
+        &mut stack.children[source_audio_track_index].items[source_audio_item_index]
+    {
+        clip.source_range.start_time.value = 1.5;
+    }
+
+    let mut dest_video = Track::new(TrackKind::Video, Some("dest-v".to_string()));
+    dest_video.items.push(Item::Gap(Gap::make_gap(10.0)));
+    stack.children.push(dest_video);
+
+    assert!(stack.move_item_at_time(
+        &result.primary_clip_id,
+        "dest-v",
+        4.0,
+        true,
+        InsertPolicy::SplitAndInsert,
+        OverlapPolicy::Override,
+    ));
+
+    let (video_track_index, video_item_index, video_item) =
+        stack.get_item(&result.primary_clip_id).unwrap();
+    let (audio_track_index, audio_item_index, audio_item) = stack.get_item(&audio_id).unwrap();
+    assert_eq!(
+        stack.children[video_track_index].get_id().as_deref(),
+        Some("dest-v")
+    );
+    assert_ne!(
+        stack.children[audio_track_index].get_id().as_deref(),
+        Some(source_audio_track_id.as_str())
+    );
+    assert_eq!(
+        stack.children[video_track_index].start_time_of_item(video_item_index),
+        4.0
+    );
+    assert_eq!(
+        stack.children[audio_track_index].start_time_of_item(audio_item_index),
+        4.0
+    );
+    assert_eq!(video_item.duration(), 3.0);
+    assert_eq!(audio_item.duration(), 3.0);
+    assert_eq!(source_start(video_item), 2.0);
+    assert_eq!(source_start(audio_item), 1.5);
+    assert_eq!(active_target_url(audio_item), Some("file:///source-audio.wav"));
+    assert_eq!(link_group_id(video_item), result.link_group_id);
+    assert_eq!(link_group_id(audio_item), result.link_group_id);
+}
+
+#[test]
 fn move_linked_item_at_time_does_not_cross_unlinked_destination_track() {
     let mut stack = Stack::default();
     stack

--- a/tellers-timeline-core/tests/linked.rs
+++ b/tellers-timeline-core/tests/linked.rs
@@ -2480,6 +2480,244 @@ fn move_linked_video_to_new_boundary_creates_audio_track_without_retiming() {
 }
 
 #[test]
+fn move_linked_video_reuses_existing_destination_audio_boundary_in_order() {
+    let mut stack = Stack::default();
+    stack
+        .children
+        .push(Track::new(TrackKind::Video, Some("source-v".to_string())));
+    let result = insert_with_audio(
+        &mut stack,
+        0,
+        0.0,
+        clip(3.0, Some("primary")),
+        vec![
+            audio_clip(3.0, "file:///a1.wav", None),
+            audio_clip(3.0, "file:///a2.wav", None),
+        ],
+    )
+    .unwrap();
+    let first_audio_id = result.audio_clips[0].0.clone();
+    let second_audio_id = result.audio_clips[1].0.clone();
+
+    let mut dest_audio_far = Track::new(TrackKind::Audio, Some("dest-a-far".to_string()));
+    dest_audio_far.items.push(Item::Gap(Gap::make_gap(10.0)));
+    let mut dest_audio_near = Track::new(TrackKind::Audio, Some("dest-a-near".to_string()));
+    dest_audio_near.items.push(Item::Gap(Gap::make_gap(10.0)));
+    let mut dest_video = Track::new(TrackKind::Video, Some("dest-v".to_string()));
+    dest_video.items.push(Item::Gap(Gap::make_gap(10.0)));
+    stack.children.push(dest_audio_far);
+    stack.children.push(dest_audio_near);
+    stack.children.push(dest_video);
+    let track_count = stack.children.len();
+
+    assert!(stack.move_item_at_time(
+        "primary",
+        "dest-v",
+        4.0,
+        true,
+        InsertPolicy::SplitAndInsert,
+        OverlapPolicy::Override,
+    ));
+
+    assert_eq!(stack.children.len(), track_count);
+    assert_eq!(
+        stack.children[stack.get_item("primary").unwrap().0]
+            .get_id()
+            .as_deref(),
+        Some("dest-v")
+    );
+    assert_eq!(
+        stack.children[stack.get_item(&first_audio_id).unwrap().0]
+            .get_id()
+            .as_deref(),
+        Some("dest-a-near")
+    );
+    assert_eq!(
+        stack.children[stack.get_item(&second_audio_id).unwrap().0]
+            .get_id()
+            .as_deref(),
+        Some("dest-a-far")
+    );
+    for item_id in ["primary", &first_audio_id, &second_audio_id] {
+        let (track_index, item_index, item) = stack.get_item(item_id).unwrap();
+        assert_eq!(stack.children[track_index].start_time_of_item(item_index), 4.0);
+        assert_eq!(item.duration(), 3.0);
+        assert_eq!(link_group_id(item), result.link_group_id);
+    }
+}
+
+#[test]
+fn move_linked_video_creates_only_missing_destination_audio_tracks() {
+    let mut stack = Stack::default();
+    stack
+        .children
+        .push(Track::new(TrackKind::Video, Some("source-v".to_string())));
+    let result = insert_with_audio(
+        &mut stack,
+        0,
+        0.0,
+        clip(3.0, Some("primary")),
+        vec![
+            audio_clip(3.0, "file:///a1.wav", None),
+            audio_clip(3.0, "file:///a2.wav", None),
+        ],
+    )
+    .unwrap();
+    let first_audio_id = result.audio_clips[0].0.clone();
+    let second_audio_id = result.audio_clips[1].0.clone();
+    let source_audio_track_ids: Vec<_> = [&first_audio_id, &second_audio_id]
+        .iter()
+        .map(|id| {
+            let (track_index, _, _) = stack.get_item(id).unwrap();
+            stack.children[track_index].get_id().unwrap()
+        })
+        .collect();
+
+    let mut dest_audio = Track::new(TrackKind::Audio, Some("dest-a".to_string()));
+    dest_audio.items.push(Item::Gap(Gap::make_gap(10.0)));
+    let mut dest_video = Track::new(TrackKind::Video, Some("dest-v".to_string()));
+    dest_video.items.push(Item::Gap(Gap::make_gap(10.0)));
+    stack.children.push(dest_audio);
+    stack.children.push(dest_video);
+    let track_count = stack.children.len();
+
+    assert!(stack.move_item_at_time(
+        "primary",
+        "dest-v",
+        4.0,
+        true,
+        InsertPolicy::SplitAndInsert,
+        OverlapPolicy::Override,
+    ));
+
+    assert_eq!(stack.children.len(), track_count + 1);
+    assert_eq!(
+        stack.children[stack.get_item(&first_audio_id).unwrap().0]
+            .get_id()
+            .as_deref(),
+        Some("dest-a")
+    );
+    let (second_audio_track, _, second_audio_item) = stack.get_item(&second_audio_id).unwrap();
+    assert_eq!(second_audio_item.duration(), 3.0);
+    assert!(!source_audio_track_ids.contains(&stack.children[second_audio_track].get_id().unwrap()));
+    assert_ne!(
+        stack.children[second_audio_track].get_id().as_deref(),
+        Some("dest-a")
+    );
+    assert_eq!(
+        stack.children[stack.get_item("primary").unwrap().0]
+            .get_id()
+            .as_deref(),
+        Some("dest-v")
+    );
+}
+
+#[test]
+fn move_linked_audio_to_new_boundary_creates_video_track_without_retiming() {
+    let mut stack = Stack::default();
+    stack
+        .children
+        .push(Track::new(TrackKind::Audio, Some("source-a".to_string())));
+    let mut primary_audio = audio_clip(3.0, "file:///audio.wav", None);
+    primary_audio.set_id(Some("primary-audio".to_string()));
+    let result = match stack.insert_item_at_time(
+        0,
+        0.0,
+        primary_audio,
+        OverlapPolicy::Override,
+        InsertPolicy::InsertBefore,
+        None,
+        Some(Item::Clip(clip_with_media_range(3.0, 2.0, 0.0, 10.0))),
+    ) {
+        Some(InsertItemAtTimeResult::Linked(result)) => result,
+        _ => panic!("linked insert should succeed"),
+    };
+    let video_id = result.linked_video_clip_id.clone().unwrap();
+
+    let mut dest_audio = Track::new(TrackKind::Audio, Some("dest-a".to_string()));
+    dest_audio.items.push(Item::Gap(Gap::make_gap(10.0)));
+    stack.children.push(dest_audio);
+    let track_count = stack.children.len();
+
+    assert!(stack.move_item_at_time(
+        "primary-audio",
+        "dest-a",
+        4.0,
+        true,
+        InsertPolicy::SplitAndInsert,
+        OverlapPolicy::Override,
+    ));
+
+    assert_eq!(stack.children.len(), track_count + 1);
+    let (audio_track_index, audio_item_index, audio_item) =
+        stack.get_item("primary-audio").unwrap();
+    let (video_track_index, video_item_index, video_item) = stack.get_item(&video_id).unwrap();
+    assert_eq!(
+        stack.children[audio_track_index].get_id().as_deref(),
+        Some("dest-a")
+    );
+    assert_eq!(stack.children[audio_track_index].start_time_of_item(audio_item_index), 4.0);
+    assert_eq!(stack.children[video_track_index].start_time_of_item(video_item_index), 4.0);
+    assert_eq!(audio_item.duration(), 3.0);
+    assert_eq!(video_item.duration(), 3.0);
+    assert_eq!(source_start(video_item), 2.0);
+    assert_eq!(link_group_id(audio_item), result.link_group_id);
+    assert_eq!(link_group_id(video_item), result.link_group_id);
+}
+
+#[test]
+fn move_linked_video_at_index_uses_destination_boundary_without_retiming() {
+    let mut stack = Stack::default();
+    stack
+        .children
+        .push(Track::new(TrackKind::Video, Some("source-v".to_string())));
+    let result = insert_with_audio(
+        &mut stack,
+        0,
+        0.0,
+        clip_with_media_range(3.0, 2.0, 0.0, 10.0),
+        vec![audio_clip(3.0, "file:///a1.wav", None)],
+    )
+    .unwrap();
+    let audio_id = result.audio_clips[0].0.clone();
+
+    let mut dest_audio = Track::new(TrackKind::Audio, Some("dest-a".to_string()));
+    dest_audio.items.push(Item::Gap(Gap::make_gap(10.0)));
+    let mut dest_video = Track::new(TrackKind::Video, Some("dest-v".to_string()));
+    dest_video.items.push(Item::Gap(Gap::make_gap(2.0)));
+    dest_video.items.push(Item::Clip(clip(2.0, Some("dest-v-later"))));
+    stack.children.push(dest_audio);
+    stack.children.push(dest_video);
+
+    assert!(stack.move_item_at_index(
+        &result.primary_clip_id,
+        "dest-v",
+        1,
+        true,
+        OverlapPolicy::Push,
+    ));
+
+    let (video_track_index, video_item_index, video_item) =
+        stack.get_item(&result.primary_clip_id).unwrap();
+    let (audio_track_index, audio_item_index, audio_item) = stack.get_item(&audio_id).unwrap();
+    assert_eq!(
+        stack.children[video_track_index].get_id().as_deref(),
+        Some("dest-v")
+    );
+    assert_eq!(
+        stack.children[audio_track_index].get_id().as_deref(),
+        Some("dest-a")
+    );
+    assert_eq!(stack.children[video_track_index].start_time_of_item(video_item_index), 2.0);
+    assert_eq!(stack.children[audio_track_index].start_time_of_item(audio_item_index), 2.0);
+    assert_eq!(video_item.duration(), 3.0);
+    assert_eq!(audio_item.duration(), 3.0);
+    assert_eq!(source_start(video_item), 2.0);
+    assert_eq!(link_group_id(video_item), result.link_group_id);
+    assert_eq!(link_group_id(audio_item), result.link_group_id);
+}
+
+#[test]
 fn move_linked_item_at_time_does_not_cross_unlinked_destination_track() {
     let mut stack = Stack::default();
     stack

--- a/tellers-timeline-core/tests/linked.rs
+++ b/tellers-timeline-core/tests/linked.rs
@@ -157,6 +157,19 @@ fn active_target_url(item: &Item) -> Option<&str> {
         .map(String::as_str)
 }
 
+fn range_is_gap_backed_for_test(track: &Track, start: f64, end: f64) -> bool {
+    let mut pos = 0.0;
+    for item in &track.items {
+        let item_start = pos;
+        let item_end = pos + item.duration().max(0.0);
+        if item_end > start + 1e-9 && item_start < end - 1e-9 && !matches!(item, Item::Gap(_)) {
+            return false;
+        }
+        pos = item_end;
+    }
+    true
+}
+
 fn linked_clip_item(duration: f64, id: &str, link_group_id: i64) -> Item {
     let mut clip = clip(duration, Some(id));
     clip.metadata["Resolve_OTIO"] = serde_json::json!({
@@ -3034,6 +3047,83 @@ fn move_unlinked_item_pushes_full_linked_boundary_with_gap_companions() {
             stack.children[audio_track_index].items[spacer_index].duration(),
             1.0
         );
+    }
+}
+
+#[test]
+fn move_unlinked_item_pushes_full_linked_boundary_for_insert_policies() {
+    let cases = [
+        (InsertPolicy::SplitAndInsert, 0.0, 0.0, 2.0),
+        (InsertPolicy::InsertBefore, 1.5, 1.0, 2.0),
+        (InsertPolicy::InsertAfter, 0.5, 1.0, 2.0),
+        (InsertPolicy::InsertBeforeOrAfter, 1.2, 1.0, 2.0),
+    ];
+
+    for (insert_policy, dest_time, moved_start, linked_start) in cases {
+        let mut video = Track::new(TrackKind::Video, Some("v".to_string()));
+        video.items.push(Item::Clip(clip(1.0, Some("unlinked"))));
+
+        let mut stack = Stack::default();
+        stack.children.push(video);
+        let result = insert_with_audio(
+            &mut stack,
+            0,
+            1.0,
+            clip(2.0, Some("linked-video")),
+            vec![
+                audio_clip(2.0, "file:///linked-a1.wav", None),
+                audio_clip(2.0, "file:///linked-a2.wav", None),
+            ],
+        )
+        .unwrap();
+        let audio_ids: Vec<_> = result
+            .audio_clips
+            .iter()
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        assert!(stack.move_item_at_time(
+            "unlinked",
+            "v",
+            dest_time,
+            true,
+            insert_policy,
+            OverlapPolicy::Push,
+        ));
+
+        let (moved_track_index, moved_item_index, moved_item) =
+            stack.get_item("unlinked").unwrap();
+        assert_eq!(
+            stack.children[moved_track_index].start_time_of_item(moved_item_index),
+            moved_start,
+            "moved start for {insert_policy:?}"
+        );
+        assert_eq!(moved_item.duration(), 1.0);
+
+        let (linked_video_track_index, linked_video_item_index, linked_video) =
+            stack.get_item("linked-video").unwrap();
+        assert_eq!(
+            stack.children[linked_video_track_index].start_time_of_item(linked_video_item_index),
+            linked_start,
+            "linked video start for {insert_policy:?}"
+        );
+        assert_eq!(link_group_id(linked_video), result.link_group_id);
+
+        for audio_id in &audio_ids {
+            let (audio_track_index, audio_item_index, audio_item) =
+                stack.get_item(audio_id).unwrap();
+            let audio_track = &stack.children[audio_track_index];
+            assert_eq!(
+                audio_track.start_time_of_item(audio_item_index),
+                linked_start,
+                "linked audio start for {insert_policy:?}"
+            );
+            assert_eq!(link_group_id(audio_item), result.link_group_id);
+            assert!(
+                range_is_gap_backed_for_test(audio_track, moved_start, moved_start + 1.0),
+                "missing gap companion for {insert_policy:?}"
+            );
+        }
     }
 }
 

--- a/tellers-timeline-core/tests/linked.rs
+++ b/tellers-timeline-core/tests/linked.rs
@@ -702,7 +702,7 @@ fn insert_unlinked_clip_before_policy_pushes_linked_assets_from_boundary() {
 }
 
 #[test]
-fn insert_unlinked_clip_after_policy_does_not_touch_linked_assets() {
+fn insert_unlinked_clip_after_policy_adds_boundary_gap_companion() {
     let mut stack = Stack::default();
     stack
         .children
@@ -728,7 +728,7 @@ fn insert_unlinked_clip_after_policy_does_not_touch_linked_assets() {
         None,
     );
 
-    assert!(matches!(insert_result, Some(InsertItemAtTimeResult::ItemId(_))));
+    assert!(matches!(insert_result, Some(InsertItemAtTimeResult::Linked(_))));
     let (video_track_index, video_item_index, _) = stack.get_item("linked-video").unwrap();
     let (audio_track_index, audio_item_index, _) = stack.get_item(&audio_id).unwrap();
     assert_eq!(
@@ -739,6 +739,60 @@ fn insert_unlinked_clip_after_policy_does_not_touch_linked_assets() {
         stack.children[audio_track_index].start_time_of_item(audio_item_index),
         2.0
     );
+    assert_eq!(stack.children[video_track_index].total_duration(), 5.0);
+    assert_eq!(stack.children[audio_track_index].total_duration(), 5.0);
+    assert!(range_is_gap_backed_for_test(
+        &stack.children[audio_track_index],
+        4.0,
+        5.0
+    ));
+}
+
+#[test]
+fn insert_unlinked_clip_at_index_after_boundary_adds_gap_companion() {
+    let mut stack = Stack::default();
+    stack
+        .children
+        .push(Track::new(TrackKind::Video, Some("v".to_string())));
+    let result = insert_with_audio(
+        &mut stack,
+        0,
+        2.0,
+        clip(2.0, Some("linked-video")),
+        vec![audio_clip(2.0, "file:///linked-audio.wav", None)],
+    )
+    .unwrap();
+    let audio_id = result.audio_clips[0].0.clone();
+    let primary_track_index = stack.get_item("linked-video").unwrap().0;
+    let primary_track_id = stack.children[primary_track_index].get_id().unwrap();
+
+    let insert_result = stack.insert_item_at_index(
+        &primary_track_id,
+        stack.children[primary_track_index].items.len(),
+        Item::Clip(clip(1.0, Some("inserted"))),
+        OverlapPolicy::Push,
+        None,
+        None,
+    );
+
+    assert!(matches!(insert_result, Some(InsertItemAtTimeResult::Linked(_))));
+    let (video_track_index, video_item_index, _) = stack.get_item("linked-video").unwrap();
+    let (audio_track_index, audio_item_index, _) = stack.get_item(&audio_id).unwrap();
+    assert_eq!(
+        stack.children[video_track_index].start_time_of_item(video_item_index),
+        2.0
+    );
+    assert_eq!(
+        stack.children[audio_track_index].start_time_of_item(audio_item_index),
+        2.0
+    );
+    assert_eq!(stack.children[video_track_index].total_duration(), 5.0);
+    assert_eq!(stack.children[audio_track_index].total_duration(), 5.0);
+    assert!(range_is_gap_backed_for_test(
+        &stack.children[audio_track_index],
+        4.0,
+        5.0
+    ));
 }
 
 #[test]
@@ -1765,7 +1819,7 @@ fn append_linked_clip_at_index_with_override_uses_same_audio_track() {
 }
 
 #[test]
-fn insert_unlinked_clip_override_after_policy_does_not_gap_linked_asset() {
+fn insert_unlinked_clip_override_after_policy_adds_boundary_gap_companion() {
     let mut stack = Stack::default();
     stack
         .children
@@ -1791,7 +1845,7 @@ fn insert_unlinked_clip_override_after_policy_does_not_gap_linked_asset() {
         None,
     );
 
-    assert!(matches!(insert_result, Some(InsertItemAtTimeResult::ItemId(_))));
+    assert!(matches!(insert_result, Some(InsertItemAtTimeResult::Linked(_))));
     let (video_track_index, video_item_index, video_item) =
         stack.get_item("linked-video").unwrap();
     let (audio_track_index, audio_item_index, audio_item) = stack.get_item(&audio_id).unwrap();
@@ -1805,6 +1859,13 @@ fn insert_unlinked_clip_override_after_policy_does_not_gap_linked_asset() {
     );
     assert_eq!(video_item.duration(), 2.0);
     assert_eq!(audio_item.duration(), 2.0);
+    assert_eq!(stack.children[video_track_index].total_duration(), 5.0);
+    assert_eq!(stack.children[audio_track_index].total_duration(), 5.0);
+    assert!(range_is_gap_backed_for_test(
+        &stack.children[audio_track_index],
+        4.0,
+        5.0
+    ));
 }
 
 #[test]
@@ -2922,10 +2983,15 @@ fn move_unlinked_item_without_gap_pulls_later_linked_assets() {
         stack.children[video_track_index].timeline_ids(),
         vec!["linked-video", "unlinked"]
     );
-    assert_eq!(stack.children[audio_track_index].items.len(), 1);
+    assert_eq!(stack.children[audio_track_index].items.len(), 2);
     assert!(matches!(
         stack.children[audio_track_index].items[audio_item_index],
         Item::Clip(_)
+    ));
+    assert!(range_is_gap_backed_for_test(
+        &stack.children[audio_track_index],
+        2.0,
+        3.0
     ));
 }
 

--- a/tellers-timeline-core/tests/linked.rs
+++ b/tellers-timeline-core/tests/linked.rs
@@ -3230,6 +3230,121 @@ fn replace_unlinked_item_only_replaces_selected_item() {
 }
 
 #[test]
+fn replace_unlinked_item_in_linked_boundary_adds_gap_companions() {
+    let mut video = Track::new(TrackKind::Video, Some("v".to_string()));
+    video.items.push(Item::Clip(clip(1.0, Some("unlinked"))));
+
+    let mut stack = Stack::default();
+    stack.children.push(video);
+    let result = insert_with_audio(
+        &mut stack,
+        0,
+        1.0,
+        clip(2.0, Some("linked-video")),
+        vec![
+            audio_clip(2.0, "file:///linked-a1.wav", None),
+            audio_clip(2.0, "file:///linked-a2.wav", None),
+        ],
+    )
+    .unwrap();
+    let audio_ids: Vec<_> = result
+        .audio_clips
+        .iter()
+        .map(|(id, _)| id.clone())
+        .collect();
+
+    assert!(stack.replace_item(
+        "unlinked",
+        Item::Clip(clip(1.5, Some("replacement"))),
+        None,
+        None,
+    ));
+
+    let (video_track_index, video_item_index, replaced_item) =
+        stack.get_item("unlinked").unwrap();
+    assert_eq!(
+        stack.children[video_track_index].start_time_of_item(video_item_index),
+        0.0
+    );
+    assert_eq!(replaced_item.duration(), 1.5);
+    assert_eq!(link_group_id(replaced_item), None);
+    assert!(stack.get_item("replacement").is_none());
+
+    let (linked_video_track_index, linked_video_item_index, linked_video) =
+        stack.get_item("linked-video").unwrap();
+    assert_eq!(
+        stack.children[linked_video_track_index].start_time_of_item(linked_video_item_index),
+        1.5
+    );
+    assert_eq!(link_group_id(linked_video), result.link_group_id);
+
+    for audio_id in &audio_ids {
+        let (audio_track_index, audio_item_index, audio_item) = stack.get_item(audio_id).unwrap();
+        let audio_track = &stack.children[audio_track_index];
+        assert_eq!(audio_track.start_time_of_item(audio_item_index), 1.5);
+        assert_eq!(link_group_id(audio_item), result.link_group_id);
+        assert!(range_is_gap_backed_for_test(audio_track, 0.0, 1.5));
+    }
+}
+
+#[test]
+fn replace_unlinked_item_in_linked_boundary_removes_gap_companions() {
+    let mut video = Track::new(TrackKind::Video, Some("v".to_string()));
+    video.items.push(Item::Clip(clip(1.5, Some("unlinked"))));
+
+    let mut stack = Stack::default();
+    stack.children.push(video);
+    let result = insert_with_audio(
+        &mut stack,
+        0,
+        1.5,
+        clip(2.0, Some("linked-video")),
+        vec![
+            audio_clip(2.0, "file:///linked-a1.wav", None),
+            audio_clip(2.0, "file:///linked-a2.wav", None),
+        ],
+    )
+    .unwrap();
+    let audio_ids: Vec<_> = result
+        .audio_clips
+        .iter()
+        .map(|(id, _)| id.clone())
+        .collect();
+
+    assert!(stack.replace_item(
+        "unlinked",
+        Item::Clip(clip(1.0, Some("replacement"))),
+        None,
+        None,
+    ));
+
+    let (video_track_index, video_item_index, replaced_item) =
+        stack.get_item("unlinked").unwrap();
+    assert_eq!(
+        stack.children[video_track_index].start_time_of_item(video_item_index),
+        0.0
+    );
+    assert_eq!(replaced_item.duration(), 1.0);
+    assert_eq!(link_group_id(replaced_item), None);
+
+    let (linked_video_track_index, linked_video_item_index, linked_video) =
+        stack.get_item("linked-video").unwrap();
+    assert_eq!(
+        stack.children[linked_video_track_index].start_time_of_item(linked_video_item_index),
+        1.0
+    );
+    assert_eq!(link_group_id(linked_video), result.link_group_id);
+
+    for audio_id in &audio_ids {
+        let (audio_track_index, audio_item_index, audio_item) = stack.get_item(audio_id).unwrap();
+        let audio_track = &stack.children[audio_track_index];
+        assert_eq!(audio_track.start_time_of_item(audio_item_index), 1.0);
+        assert_eq!(link_group_id(audio_item), result.link_group_id);
+        assert!(range_is_gap_backed_for_test(audio_track, 0.0, 1.0));
+    }
+}
+
+#[test]
 fn replace_item_missing_active_reference_does_not_bind_default_media() {
     let mut stack = Stack::default();
     stack


### PR DESCRIPTION
## Summary
- Keep linked move focused on relocation only: no duration changes, no source-start changes, and no link metadata rewrites for moved assets.
- Resolve linked companions into the destination boundary, reusing existing boundary/gap-backed tracks and creating only the missing companion tracks.
- Align unlinked insert and replace inside linked boundaries so companion boundary tracks receive matching gaps instead of leaving later linked assets misaligned.
- Tighten public stack edit behavior so plain inserts return a valid assigned item id and successful stack edit paths finish with stack-level sanitation.

## Behavior Notes
- Unlinked edits outside a linked boundary still affect only the selected track.
- Unlinked edits inside or adjacent to a linked boundary behave as if companion gap items exist on the bound tracks.
- Linked moves preserve existing clip duration, source start, and link group identity while adapting placement to the destination boundary.
- Internal gap-only placement avoids public insert sanitation while a multi-track linked operation is still in progress.

## Tests
- `cargo test -p tellers-timeline-core linked`
- `cargo test -p tellers-timeline-core insert_plain_item`
- `cargo test -p tellers-timeline-core`

## Notes
- No public Rust or Python API signature changes.
