### PR TITLE
Give split linked clips new group ids

### DIFF
--- a/bindings/python/tests/test_linked.py
+++ b/bindings/python/tests/test_linked.py
@@ -643,9 +643,18 @@ def test_split_item_at_time_splits_linked_group():
     assert stack.tracks()[audio_track].items()[0].duration() == 2.0
     assert stack.tracks()[audio_track].items()[1].duration() == 2.0
     assert maybe_link_group_id(stack.tracks()[video_track].items()[0]) == result["link_group_id"]
-    assert maybe_link_group_id(stack.tracks()[video_track].items()[1]) == result["link_group_id"]
     assert maybe_link_group_id(stack.tracks()[audio_track].items()[0]) == result["link_group_id"]
-    assert maybe_link_group_id(stack.tracks()[audio_track].items()[1]) == result["link_group_id"]
+    right_link_group_id = result["link_group_id"] + 1
+    assert maybe_link_group_id(stack.tracks()[video_track].items()[1]) == right_link_group_id
+    assert maybe_link_group_id(stack.tracks()[audio_track].items()[1]) == right_link_group_id
+    assert (
+        stack.tracks()[video_track].items()[0].get_id()
+        != stack.tracks()[video_track].items()[1].get_id()
+    )
+    assert (
+        stack.tracks()[audio_track].items()[0].get_id()
+        != stack.tracks()[audio_track].items()[1].get_id()
+    )
 
 
 def test_split_unlinked_item_only_splits_selected_track():
@@ -1259,7 +1268,7 @@ def test_resize_video_updates_linked_audio_with_same_initial_boundary():
     assert audio_item.duration() == new_duration
 
 
-def test_resize_item_moves_linked_group_by_selected_delta():
+def test_resize_item_moves_selected_split_linked_group_by_selected_delta():
     stack = Stack([Track(kind="video", id="v")])
     result = stack.insert_item_at_time(
         0,
@@ -1275,6 +1284,9 @@ def test_resize_item_moves_linked_group_by_selected_delta():
     audio_track = stack.get_item(audio_id)[0]
     right_video_id = stack.tracks()[primary_track].items()[1].get_id()
     right_audio_id = stack.tracks()[audio_track].items()[1].get_id()
+    right_link_group_id = maybe_link_group_id(stack.get_item(right_video_id)[2])
+    assert right_link_group_id == maybe_link_group_id(stack.get_item(right_audio_id)[2])
+    assert right_link_group_id != result["link_group_id"]
 
     assert stack.resize_item("primary", 1.0, 1.0, "override", False)
 
@@ -1283,6 +1295,6 @@ def test_resize_item_moves_linked_group_by_selected_delta():
         assert stack.tracks()[track_index].start_time_of_item(item_index) == 1.0
         assert item.duration() == 1.0
     for item_id in [right_video_id, right_audio_id]:
-        track_index, item_index, item = stack.get_item(item_id)
-        assert stack.tracks()[track_index].start_time_of_item(item_index) == 3.0
+        _, _, item = stack.get_item(item_id)
         assert item.duration() == 1.0
+        assert maybe_link_group_id(item) == right_link_group_id

--- a/tellers-timeline-core/src/stack_methods/stack_item_split.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_item_split.rs
@@ -23,7 +23,8 @@ impl Stack {
             return true;
         }
 
-        let targets = super::resolve_link_group_id(&selected_clip.metadata)
+        let selected_link_group_id = super::resolve_link_group_id(&selected_clip.metadata);
+        let targets = selected_link_group_id
             .map(|link_group_id| self.linked_group_targets(link_group_id))
             .filter(|targets| targets.len() > 1)
             .unwrap_or_else(|| vec![(selected_track_index, selected_item_index)]);
@@ -49,14 +50,28 @@ impl Stack {
             }
         }
 
+        let right_link_group_id = (targets.len() > 1).then(|| self.next_link_group_id());
         let mut target_tracks: Vec<_> = targets
-            .into_iter()
-            .map(|(track_index, _)| track_index)
+            .iter()
+            .map(|(track_index, _)| *track_index)
             .collect();
         target_tracks.sort_unstable();
         target_tracks.dedup();
         for track_index in target_tracks {
             self.children[track_index].split_at_time(split_time);
+        }
+        if let Some(link_group_id) = right_link_group_id {
+            for (track_index, item_index) in &targets {
+                let Some(Item::Clip(clip)) = self
+                    .children
+                    .get_mut(*track_index)
+                    .and_then(|track| track.items.get_mut(item_index + 1))
+                else {
+                    *self = backup;
+                    return false;
+                };
+                super::set_resolve_link_group_id(&mut clip.metadata, link_group_id);
+            }
         }
         self.sanitize();
         true

--- a/tellers-timeline-core/tests/linked.rs
+++ b/tellers-timeline-core/tests/linked.rs
@@ -3857,7 +3857,7 @@ fn split_item_at_time_splits_linked_group() {
     );
     assert_eq!(
         link_group_id(&stack.children[0].items[1]),
-        result.link_group_id
+        Some(result.link_group_id.unwrap() + 1)
     );
     assert_eq!(
         link_group_id(&stack.children[result.audio_clips[0].1].items[0]),
@@ -3865,9 +3865,17 @@ fn split_item_at_time_splits_linked_group() {
     );
     assert_eq!(
         link_group_id(&stack.children[result.audio_clips[0].1].items[1]),
-        result.link_group_id
+        Some(result.link_group_id.unwrap() + 1)
     );
     assert!(stack.get_item(&audio_id).is_some());
+    assert_ne!(
+        stack.children[0].items[0].get_id(),
+        stack.children[0].items[1].get_id()
+    );
+    assert_ne!(
+        stack.children[result.audio_clips[0].1].items[0].get_id(),
+        stack.children[result.audio_clips[0].1].items[1].get_id()
+    );
 }
 
 #[test]
@@ -4005,7 +4013,7 @@ fn resize_primary_clip_over_itself_keeps_linked_group() {
 }
 
 #[test]
-fn resize_item_moves_linked_group_by_selected_delta() {
+fn resize_item_moves_selected_split_linked_group_by_selected_delta() {
     let mut stack = Stack::default();
     stack
         .children
@@ -4026,6 +4034,12 @@ fn resize_item_moves_linked_group_by_selected_delta() {
     let right_audio_id = stack.children[stack.get_item(&audio_id).unwrap().0].items[1]
         .get_id()
         .unwrap();
+    let right_link_group_id = link_group_id(stack.get_item(&right_video_id).unwrap().2);
+    assert_eq!(
+        right_link_group_id,
+        link_group_id(stack.get_item(&right_audio_id).unwrap().2)
+    );
+    assert_ne!(right_link_group_id, result.link_group_id);
 
     assert!(stack.resize_item("primary", 1.0, 1.0, OverlapPolicy::Override, false));
 
@@ -4038,12 +4052,9 @@ fn resize_item_moves_linked_group_by_selected_delta() {
         assert_eq!(item.duration(), 1.0);
     }
     for item_id in [&right_video_id, &right_audio_id] {
-        let (track_index, item_index, item) = stack.get_item(item_id).unwrap();
-        assert_eq!(
-            stack.children[track_index].start_time_of_item(item_index),
-            3.0
-        );
+        let (_, _, item) = stack.get_item(item_id).unwrap();
         assert_eq!(item.duration(), 1.0);
+        assert_eq!(link_group_id(item), right_link_group_id);
     }
 }
 


### PR DESCRIPTION
## Summary
- Assign the right-hand side of a split linked clip group to a fresh Resolve link group id.
- Keep the left-hand split pieces on the original link group and preserve fresh timeline ids for the new clip pieces.
- Update Rust and Python linked split expectations for the new split-group behavior.

## Root Cause
Splitting a linked clip duplicated the linked-group metadata onto both halves, so the second half remained part of the original linked clip group instead of becoming its own linked clip group.

## Validation
- `cargo test -p tellers-timeline-core`

Note: Python linked tests were updated but not run locally because the repository venv does not have `pytest` installed.