### PR TITLE
Fix linked audio push inserts

### DIFF
--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -716,7 +716,7 @@ impl Stack {
     fn flatten_boundary_for_link_groups(
         &self,
         anchor_track_index: usize,
-        _link_groups: &[i64],
+        link_groups: &[i64],
     ) -> FlattenedBoundary {
         if anchor_track_index >= self.children.len() {
             return FlattenedBoundary {
@@ -744,6 +744,23 @@ impl Stack {
                 }
                 track_indices.reverse();
                 track_indices.push(anchor_track_index);
+                if !link_groups.is_empty() {
+                    for track_index in (anchor_track_index + 1)..self.children.len() {
+                        if self.children[track_index].kind != TrackKind::Audio {
+                            break;
+                        }
+                        if track_is_empty_boundary(&self.children[track_index]) {
+                            track_indices.push(track_index);
+                            break;
+                        }
+                        if !self
+                            .track_matches_primary_link_boundary(anchor_track_index, track_index)
+                        {
+                            break;
+                        }
+                        track_indices.push(track_index);
+                    }
+                }
             }
             TrackKind::Audio => {
                 let mut audio_start = anchor_track_index;
@@ -755,6 +772,17 @@ impl Stack {
                         break;
                     }
                     audio_start = previous;
+                }
+                if !link_groups.is_empty() {
+                    let previous_video_index = audio_start.checked_sub(1);
+                    if let Some(video_index) = previous_video_index {
+                        if self.children[video_index].kind == TrackKind::Video
+                            && self
+                                .track_matches_primary_link_boundary(anchor_track_index, video_index)
+                        {
+                            track_indices.push(video_index);
+                        }
+                    }
                 }
                 for track_index in audio_start..self.children.len() {
                     if self.children[track_index].kind != TrackKind::Audio {

--- a/tellers-timeline-core/tests/linked.rs
+++ b/tellers-timeline-core/tests/linked.rs
@@ -199,6 +199,26 @@ fn insert_with_audio(
     }
 }
 
+fn stack_with_linked_audio_below_video() -> Stack {
+    let mut video = Track::new(TrackKind::Video, Some("v".to_string()));
+    video.items.push(Item::Gap(Gap::make_gap(2.0)));
+    video.items.push(Item::Clip(clip(2.0, Some("linked-video"))));
+    let mut audio = Track::new(TrackKind::Audio, Some("a".to_string()));
+    audio.items.push(Item::Gap(Gap::make_gap(2.0)));
+    audio
+        .items
+        .push(audio_clip(2.0, "file:///linked-audio.wav", None));
+    audio.items[1].set_id(Some("linked-audio".to_string()));
+
+    let mut stack = Stack::default();
+    stack.children.push(video);
+    stack.children.push(audio);
+    stack
+        .link_item(&["linked-video".to_string(), "linked-audio".to_string()])
+        .unwrap();
+    stack
+}
+
 #[test]
 fn linked_insert_adds_primary_and_audio_tracks_without_touching_clips() {
     let mut video = Track::new(TrackKind::Video, Some("video-track".to_string()));
@@ -616,6 +636,118 @@ fn insert_unlinked_clip_with_push_moves_later_linked_assets() {
         3.0
     );
     assert_eq!(audio_item.duration(), 2.0);
+}
+
+#[test]
+fn insert_unlinked_clip_with_push_moves_linked_audio_below_video() {
+    let mut stack = stack_with_linked_audio_below_video();
+
+    let insert_result = stack.insert_item_at_time(
+        0,
+        0.0,
+        Item::Clip(clip(1.0, Some("inserted"))),
+        OverlapPolicy::Push,
+        InsertPolicy::SplitAndInsert,
+        None,
+        None,
+    );
+
+    assert!(matches!(insert_result, Some(InsertItemAtTimeResult::Linked(_))));
+    let (video_track_index, video_item_index, _) = stack.get_item("linked-video").unwrap();
+    let (audio_track_index, audio_item_index, audio_item) = stack.get_item("linked-audio").unwrap();
+    assert_eq!(
+        stack.children[video_track_index].start_time_of_item(video_item_index),
+        3.0
+    );
+    assert_eq!(
+        stack.children[audio_track_index].start_time_of_item(audio_item_index),
+        3.0
+    );
+    assert_eq!(audio_item.duration(), 2.0);
+}
+
+#[test]
+fn insert_unlinked_clip_with_push_moves_linked_audio_below_video_for_time_policies() {
+    for (insert_policy, dest_time, expected_start) in [
+        (InsertPolicy::InsertBefore, 3.0, 3.0),
+        (InsertPolicy::InsertAfter, 3.0, 2.0),
+        (InsertPolicy::InsertBeforeOrAfter, 2.25, 3.0),
+        (InsertPolicy::InsertBeforeOrAfter, 3.75, 2.0),
+    ] {
+        let mut stack = stack_with_linked_audio_below_video();
+
+        let insert_result = stack.insert_item_at_time(
+            0,
+            dest_time,
+            Item::Clip(clip(1.0, Some("inserted"))),
+            OverlapPolicy::Push,
+            insert_policy,
+            None,
+            None,
+        );
+
+        assert!(matches!(insert_result, Some(InsertItemAtTimeResult::Linked(_))));
+        let (video_track_index, video_item_index, _) = stack.get_item("linked-video").unwrap();
+        let (audio_track_index, audio_item_index, _) = stack.get_item("linked-audio").unwrap();
+        assert_eq!(
+            stack.children[video_track_index].start_time_of_item(video_item_index),
+            expected_start
+        );
+        assert_eq!(
+            stack.children[audio_track_index].start_time_of_item(audio_item_index),
+            expected_start
+        );
+    }
+}
+
+#[test]
+fn insert_unlinked_clip_at_index_with_push_moves_linked_audio_below_video() {
+    let mut stack = stack_with_linked_audio_below_video();
+
+    let insert_result = stack.insert_item_at_index(
+        "v",
+        0,
+        Item::Clip(clip(1.0, Some("inserted"))),
+        OverlapPolicy::Push,
+        None,
+        None,
+    );
+
+    assert!(matches!(insert_result, Some(InsertItemAtTimeResult::Linked(_))));
+    let (video_track_index, video_item_index, _) = stack.get_item("linked-video").unwrap();
+    let (audio_track_index, audio_item_index, audio_item) = stack.get_item("linked-audio").unwrap();
+    assert_eq!(
+        stack.children[video_track_index].start_time_of_item(video_item_index),
+        3.0
+    );
+    assert_eq!(
+        stack.children[audio_track_index].start_time_of_item(audio_item_index),
+        3.0
+    );
+    assert_eq!(audio_item.duration(), 2.0);
+}
+
+#[test]
+fn insert_unlinked_clip_with_override_updates_linked_audio_below_video() {
+    let mut stack = stack_with_linked_audio_below_video();
+
+    let insert_result = stack.insert_item_at_time(
+        0,
+        3.0,
+        Item::Clip(clip(1.0, Some("inserted"))),
+        OverlapPolicy::Override,
+        InsertPolicy::SplitAndInsert,
+        None,
+        None,
+    );
+
+    assert!(matches!(insert_result, Some(InsertItemAtTimeResult::Linked(_))));
+    let (audio_track_index, _, _) = stack.get_item("linked-audio").unwrap();
+    assert!(range_is_gap_backed_for_test(
+        &stack.children[audio_track_index],
+        3.0,
+        4.0
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Include existing linked audio tracks below video tracks when resolving linked insert boundaries.
- Preserve empty-track boundary behavior while allowing linked video/audio layouts in either adjacent order.
- Add regression coverage for time insert policies, index insert, push, and override behavior.

## Root Cause

Plain timeline inserts with Push could enter linked insert handling, but boundary discovery only considered linked audio tracks above a video track. In timelines where linked audio sits below the video track, the video moved while the associated audio stayed behind.

## Validation

- cargo test -p tellers-timeline-core