### PR TITLE
Fix linked audio move boundary

### DIFF
--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -338,6 +338,7 @@ impl Stack {
         duration: Seconds,
         created_track_indices: &mut Vec<usize>,
         used_audio_indices: &[usize],
+        used_audio_boundary_indices: &[usize],
     ) -> Option<usize> {
         let end_time = dest_time + duration;
         match self.children.get(primary_track_index)?.kind {
@@ -347,8 +348,17 @@ impl Stack {
                     audio_start -= 1;
                 }
 
+                let mut crossed_used_audio_boundary = false;
                 for audio_index in (audio_start..primary_track_index).rev() {
                     if used_audio_indices.contains(&audio_index) {
+                        if used_audio_boundary_indices.contains(&audio_index) {
+                            crossed_used_audio_boundary = true;
+                        }
+                        continue;
+                    }
+                    if crossed_used_audio_boundary
+                        && !track_is_empty_boundary(&self.children[audio_index])
+                    {
                         continue;
                     }
                     if range_is_gap_backed(&self.children[audio_index], dest_time, end_time) {
@@ -1989,6 +1999,7 @@ impl Stack {
                         moved_duration,
                         &mut created_track_indices,
                         &used_audio_track_indices,
+                        &used_audio_boundary_indices,
                     ) else {
                         *self = backup;
                         return false;

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -716,7 +716,7 @@ impl Stack {
     fn flatten_boundary_for_link_groups(
         &self,
         anchor_track_index: usize,
-        _link_groups: &[i64],
+        link_groups: &[i64],
     ) -> FlattenedBoundary {
         if anchor_track_index >= self.children.len() {
             return FlattenedBoundary {
@@ -744,6 +744,23 @@ impl Stack {
                 }
                 track_indices.reverse();
                 track_indices.push(anchor_track_index);
+                if !link_groups.is_empty() {
+                    for track_index in (anchor_track_index + 1)..self.children.len() {
+                        if self.children[track_index].kind != TrackKind::Audio {
+                            break;
+                        }
+                        if track_is_empty_boundary(&self.children[track_index]) {
+                            track_indices.push(track_index);
+                            break;
+                        }
+                        if !self
+                            .track_matches_primary_link_boundary(anchor_track_index, track_index)
+                        {
+                            break;
+                        }
+                        track_indices.push(track_index);
+                    }
+                }
             }
             TrackKind::Audio => {
                 let mut audio_start = anchor_track_index;
@@ -755,6 +772,17 @@ impl Stack {
                         break;
                     }
                     audio_start = previous;
+                }
+                if !link_groups.is_empty() {
+                    let previous_video_index = audio_start.checked_sub(1);
+                    if let Some(video_index) = previous_video_index {
+                        if self.children[video_index].kind == TrackKind::Video
+                            && self
+                                .track_matches_primary_link_boundary(anchor_track_index, video_index)
+                        {
+                            track_indices.push(video_index);
+                        }
+                    }
                 }
                 for track_index in audio_start..self.children.len() {
                     if self.children[track_index].kind != TrackKind::Audio {

--- a/tellers-timeline-core/tests/linked.rs
+++ b/tellers-timeline-core/tests/linked.rs
@@ -2819,6 +2819,80 @@ fn move_linked_video_creates_only_missing_destination_audio_tracks() {
 }
 
 #[test]
+fn move_linked_video_does_not_reuse_audio_track_across_empty_destination_boundary() {
+    let mut stack = Stack::default();
+    stack
+        .children
+        .push(Track::new(TrackKind::Video, Some("source-v".to_string())));
+    let result = insert_with_audio(
+        &mut stack,
+        0,
+        0.0,
+        clip(3.0, Some("primary")),
+        vec![
+            audio_clip(3.0, "file:///a1.wav", None),
+            audio_clip(3.0, "file:///a2.wav", None),
+        ],
+    )
+    .unwrap();
+    let first_audio_id = result.audio_clips[0].0.clone();
+    let second_audio_id = result.audio_clips[1].0.clone();
+
+    let mut previous_audio = Track::new(TrackKind::Audio, Some("previous-a".to_string()));
+    previous_audio
+        .items
+        .push(audio_clip(1.0, "file:///previous-a.wav", None));
+    previous_audio.items[0].set_id(Some("previous-a-clip".to_string()));
+    previous_audio.items.push(Item::Gap(Gap::make_gap(9.0)));
+    let mut destination_boundary_audio =
+        Track::new(TrackKind::Audio, Some("dest-boundary-a".to_string()));
+    destination_boundary_audio
+        .items
+        .push(Item::Gap(Gap::make_gap(10.0)));
+    let mut dest_video = Track::new(TrackKind::Video, Some("dest-v".to_string()));
+    dest_video.items.push(Item::Gap(Gap::make_gap(10.0)));
+    stack.children.push(previous_audio);
+    stack.children.push(destination_boundary_audio);
+    stack.children.push(dest_video);
+    let track_count = stack.children.len();
+
+    assert!(stack.move_item_at_time(
+        "primary",
+        "dest-v",
+        4.0,
+        true,
+        InsertPolicy::SplitAndInsert,
+        OverlapPolicy::Override,
+    ));
+
+    assert_eq!(stack.children.len(), track_count + 1);
+    assert_eq!(
+        stack.children[stack.get_item(&first_audio_id).unwrap().0]
+            .get_id()
+            .as_deref(),
+        Some("dest-boundary-a")
+    );
+    assert_ne!(
+        stack.children[stack.get_item(&second_audio_id).unwrap().0]
+            .get_id()
+            .as_deref(),
+        Some("previous-a")
+    );
+    assert_eq!(
+        stack.children[stack.get_item("primary").unwrap().0]
+            .get_id()
+            .as_deref(),
+        Some("dest-v")
+    );
+    for item_id in ["primary", &first_audio_id, &second_audio_id] {
+        let (track_index, item_index, item) = stack.get_item(item_id).unwrap();
+        assert_eq!(stack.children[track_index].start_time_of_item(item_index), 4.0);
+        assert_eq!(item.duration(), 3.0);
+        assert_eq!(link_group_id(item), result.link_group_id);
+    }
+}
+
+#[test]
 fn move_linked_audio_to_new_boundary_creates_video_track_without_retiming() {
     let mut stack = Stack::default();
     stack

--- a/tellers-timeline-core/tests/linked.rs
+++ b/tellers-timeline-core/tests/linked.rs
@@ -199,6 +199,26 @@ fn insert_with_audio(
     }
 }
 
+fn stack_with_linked_audio_below_video() -> Stack {
+    let mut video = Track::new(TrackKind::Video, Some("v".to_string()));
+    video.items.push(Item::Gap(Gap::make_gap(2.0)));
+    video.items.push(Item::Clip(clip(2.0, Some("linked-video"))));
+    let mut audio = Track::new(TrackKind::Audio, Some("a".to_string()));
+    audio.items.push(Item::Gap(Gap::make_gap(2.0)));
+    audio
+        .items
+        .push(audio_clip(2.0, "file:///linked-audio.wav", None));
+    audio.items[1].set_id(Some("linked-audio".to_string()));
+
+    let mut stack = Stack::default();
+    stack.children.push(video);
+    stack.children.push(audio);
+    stack
+        .link_item(&["linked-video".to_string(), "linked-audio".to_string()])
+        .unwrap();
+    stack
+}
+
 #[test]
 fn linked_insert_adds_primary_and_audio_tracks_without_touching_clips() {
     let mut video = Track::new(TrackKind::Video, Some("video-track".to_string()));
@@ -616,6 +636,118 @@ fn insert_unlinked_clip_with_push_moves_later_linked_assets() {
         3.0
     );
     assert_eq!(audio_item.duration(), 2.0);
+}
+
+#[test]
+fn insert_unlinked_clip_with_push_moves_linked_audio_below_video() {
+    let mut stack = stack_with_linked_audio_below_video();
+
+    let insert_result = stack.insert_item_at_time(
+        0,
+        0.0,
+        Item::Clip(clip(1.0, Some("inserted"))),
+        OverlapPolicy::Push,
+        InsertPolicy::SplitAndInsert,
+        None,
+        None,
+    );
+
+    assert!(matches!(insert_result, Some(InsertItemAtTimeResult::Linked(_))));
+    let (video_track_index, video_item_index, _) = stack.get_item("linked-video").unwrap();
+    let (audio_track_index, audio_item_index, audio_item) = stack.get_item("linked-audio").unwrap();
+    assert_eq!(
+        stack.children[video_track_index].start_time_of_item(video_item_index),
+        3.0
+    );
+    assert_eq!(
+        stack.children[audio_track_index].start_time_of_item(audio_item_index),
+        3.0
+    );
+    assert_eq!(audio_item.duration(), 2.0);
+}
+
+#[test]
+fn insert_unlinked_clip_with_push_moves_linked_audio_below_video_for_time_policies() {
+    for (insert_policy, dest_time, expected_start) in [
+        (InsertPolicy::InsertBefore, 3.0, 3.0),
+        (InsertPolicy::InsertAfter, 3.0, 2.0),
+        (InsertPolicy::InsertBeforeOrAfter, 2.25, 3.0),
+        (InsertPolicy::InsertBeforeOrAfter, 3.75, 2.0),
+    ] {
+        let mut stack = stack_with_linked_audio_below_video();
+
+        let insert_result = stack.insert_item_at_time(
+            0,
+            dest_time,
+            Item::Clip(clip(1.0, Some("inserted"))),
+            OverlapPolicy::Push,
+            insert_policy,
+            None,
+            None,
+        );
+
+        assert!(matches!(insert_result, Some(InsertItemAtTimeResult::Linked(_))));
+        let (video_track_index, video_item_index, _) = stack.get_item("linked-video").unwrap();
+        let (audio_track_index, audio_item_index, _) = stack.get_item("linked-audio").unwrap();
+        assert_eq!(
+            stack.children[video_track_index].start_time_of_item(video_item_index),
+            expected_start
+        );
+        assert_eq!(
+            stack.children[audio_track_index].start_time_of_item(audio_item_index),
+            expected_start
+        );
+    }
+}
+
+#[test]
+fn insert_unlinked_clip_at_index_with_push_moves_linked_audio_below_video() {
+    let mut stack = stack_with_linked_audio_below_video();
+
+    let insert_result = stack.insert_item_at_index(
+        "v",
+        0,
+        Item::Clip(clip(1.0, Some("inserted"))),
+        OverlapPolicy::Push,
+        None,
+        None,
+    );
+
+    assert!(matches!(insert_result, Some(InsertItemAtTimeResult::Linked(_))));
+    let (video_track_index, video_item_index, _) = stack.get_item("linked-video").unwrap();
+    let (audio_track_index, audio_item_index, audio_item) = stack.get_item("linked-audio").unwrap();
+    assert_eq!(
+        stack.children[video_track_index].start_time_of_item(video_item_index),
+        3.0
+    );
+    assert_eq!(
+        stack.children[audio_track_index].start_time_of_item(audio_item_index),
+        3.0
+    );
+    assert_eq!(audio_item.duration(), 2.0);
+}
+
+#[test]
+fn insert_unlinked_clip_with_override_updates_linked_audio_below_video() {
+    let mut stack = stack_with_linked_audio_below_video();
+
+    let insert_result = stack.insert_item_at_time(
+        0,
+        3.0,
+        Item::Clip(clip(1.0, Some("inserted"))),
+        OverlapPolicy::Override,
+        InsertPolicy::SplitAndInsert,
+        None,
+        None,
+    );
+
+    assert!(matches!(insert_result, Some(InsertItemAtTimeResult::Linked(_))));
+    let (audio_track_index, _, _) = stack.get_item("linked-audio").unwrap();
+    assert!(range_is_gap_backed_for_test(
+        &stack.children[audio_track_index],
+        3.0,
+        4.0
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes linked clip movement so moving a video clip to another video track keeps its linked audio clips inside the destination boundary group.

The linked move helper now treats a destination boundary audio track that has already been consumed during the move as a boundary marker for later audio companions. It can still reuse all-empty destination audio tracks, but it no longer crosses into an older non-empty audio track just because the target time range is gap-backed.

## Impact

- Linked audio follows video moves into the new destination boundary.
- Missing destination audio tracks are created where needed.
- Existing destination all-gap audio tracks remain reusable.

## Validation

- cargo test -p tellers-timeline-core
