### PR TITLE
Reuse linked move destination boundary

### DIFF
--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -339,6 +339,7 @@ impl Stack {
         created_track_indices: &mut Vec<usize>,
         used_audio_indices: &[usize],
         used_audio_boundary_indices: &[usize],
+        overlap_policy: OverlapPolicy,
     ) -> Option<usize> {
         let end_time = dest_time + duration;
         match self.children.get(primary_track_index)?.kind {
@@ -362,6 +363,14 @@ impl Stack {
                         continue;
                     }
                     if range_is_gap_backed(&self.children[audio_index], dest_time, end_time) {
+                        return Some(audio_index);
+                    }
+                    let can_push_existing_boundary = overlap_policy == OverlapPolicy::Push
+                        && self.track_matches_primary_link_boundary(
+                            primary_track_index,
+                            audio_index,
+                        );
+                    if can_push_existing_boundary {
                         return Some(audio_index);
                     }
                 }
@@ -2000,6 +2009,7 @@ impl Stack {
                         &mut created_track_indices,
                         &used_audio_track_indices,
                         &used_audio_boundary_indices,
+                        overlap_policy,
                     ) else {
                         *self = backup;
                         return false;

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -339,7 +339,6 @@ impl Stack {
         created_track_indices: &mut Vec<usize>,
         used_audio_indices: &[usize],
         used_audio_boundary_indices: &[usize],
-        overlap_policy: OverlapPolicy,
     ) -> Option<usize> {
         let end_time = dest_time + duration;
         match self.children.get(primary_track_index)?.kind {
@@ -365,12 +364,7 @@ impl Stack {
                     if range_is_gap_backed(&self.children[audio_index], dest_time, end_time) {
                         return Some(audio_index);
                     }
-                    let can_push_existing_boundary = overlap_policy == OverlapPolicy::Push
-                        && self.track_matches_primary_link_boundary(
-                            primary_track_index,
-                            audio_index,
-                        );
-                    if can_push_existing_boundary {
+                    if self.track_matches_primary_link_boundary(primary_track_index, audio_index) {
                         return Some(audio_index);
                     }
                 }
@@ -2009,7 +2003,6 @@ impl Stack {
                         &mut created_track_indices,
                         &used_audio_track_indices,
                         &used_audio_boundary_indices,
-                        overlap_policy,
                     ) else {
                         *self = backup;
                         return false;

--- a/tellers-timeline-core/tests/linked.rs
+++ b/tellers-timeline-core/tests/linked.rs
@@ -2829,6 +2829,74 @@ fn move_linked_video_reuses_destination_boundary_with_existing_linked_clip() {
 }
 
 #[test]
+fn move_linked_video_override_reuses_destination_boundary_with_existing_linked_clip() {
+    let mut stack = Stack::default();
+    stack
+        .children
+        .push(Track::new(TrackKind::Video, Some("source-v".to_string())));
+    let source_result = insert_with_audio(
+        &mut stack,
+        0,
+        0.0,
+        clip(3.0, Some("moving-video")),
+        vec![audio_clip(3.0, "file:///moving-audio.wav", None)],
+    )
+    .unwrap();
+    let moving_audio_id = source_result.audio_clips[0].0.clone();
+
+    let mut dest_audio = Track::new(TrackKind::Audio, Some("dest-a".to_string()));
+    dest_audio.items.push(Item::Gap(Gap::make_gap(10.0)));
+    let mut dest_video = Track::new(TrackKind::Video, Some("dest-v".to_string()));
+    dest_video.items.push(Item::Gap(Gap::make_gap(10.0)));
+    stack.children.push(dest_audio);
+    stack.children.push(dest_video);
+    let dest_video_index = stack
+        .get_track_by_id("dest-v")
+        .map(|(index, _)| index)
+        .unwrap();
+    let dest_result = insert_with_audio(
+        &mut stack,
+        dest_video_index,
+        0.0,
+        clip(2.0, Some("existing-video")),
+        vec![audio_clip(2.0, "file:///existing-audio.wav", None)],
+    )
+    .unwrap();
+    let existing_audio_id = dest_result.audio_clips[0].0.clone();
+    let track_count = stack.children.len();
+
+    assert!(stack.move_item_at_time(
+        "moving-video",
+        "dest-v",
+        0.0,
+        true,
+        InsertPolicy::InsertBefore,
+        OverlapPolicy::Override,
+    ));
+
+    assert_eq!(stack.children.len(), track_count);
+    assert_eq!(
+        stack.children[stack.get_item("moving-video").unwrap().0]
+            .get_id()
+            .as_deref(),
+        Some("dest-v")
+    );
+    let (moving_audio_track, moving_audio_index, moving_audio_item) =
+        stack.get_item(&moving_audio_id).unwrap();
+    assert_eq!(
+        stack.children[moving_audio_track].get_id().as_deref(),
+        Some("dest-a")
+    );
+    assert_eq!(
+        stack.children[moving_audio_track].start_time_of_item(moving_audio_index),
+        0.0
+    );
+    assert_eq!(link_group_id(moving_audio_item), source_result.link_group_id);
+    assert!(stack.get_item("existing-video").is_none());
+    assert!(stack.get_item(&existing_audio_id).is_none());
+}
+
+#[test]
 fn move_linked_video_creates_only_missing_destination_audio_tracks() {
     let mut stack = Stack::default();
     stack

--- a/tellers-timeline-core/tests/linked.rs
+++ b/tellers-timeline-core/tests/linked.rs
@@ -2753,6 +2753,82 @@ fn move_linked_video_reuses_existing_destination_audio_boundary_in_order() {
 }
 
 #[test]
+fn move_linked_video_reuses_destination_boundary_with_existing_linked_clip() {
+    let mut stack = Stack::default();
+    stack
+        .children
+        .push(Track::new(TrackKind::Video, Some("source-v".to_string())));
+    let source_result = insert_with_audio(
+        &mut stack,
+        0,
+        0.0,
+        clip(3.0, Some("moving-video")),
+        vec![audio_clip(3.0, "file:///moving-audio.wav", None)],
+    )
+    .unwrap();
+    let moving_audio_id = source_result.audio_clips[0].0.clone();
+
+    let mut dest_audio = Track::new(TrackKind::Audio, Some("dest-a".to_string()));
+    dest_audio.items.push(Item::Gap(Gap::make_gap(10.0)));
+    let mut dest_video = Track::new(TrackKind::Video, Some("dest-v".to_string()));
+    dest_video.items.push(Item::Gap(Gap::make_gap(10.0)));
+    stack.children.push(dest_audio);
+    stack.children.push(dest_video);
+    let dest_video_index = stack
+        .get_track_by_id("dest-v")
+        .map(|(index, _)| index)
+        .unwrap();
+    let dest_result = insert_with_audio(
+        &mut stack,
+        dest_video_index,
+        0.0,
+        clip(2.0, Some("existing-video")),
+        vec![audio_clip(2.0, "file:///existing-audio.wav", None)],
+    )
+    .unwrap();
+    let existing_audio_id = dest_result.audio_clips[0].0.clone();
+    let track_count = stack.children.len();
+
+    assert!(stack.move_item_at_time(
+        "moving-video",
+        "dest-v",
+        0.0,
+        true,
+        InsertPolicy::InsertBefore,
+        OverlapPolicy::Push,
+    ));
+
+    assert_eq!(stack.children.len(), track_count);
+    assert_eq!(
+        stack.children[stack.get_item("moving-video").unwrap().0]
+            .get_id()
+            .as_deref(),
+        Some("dest-v")
+    );
+    assert_eq!(
+        stack.children[stack.get_item(&moving_audio_id).unwrap().0]
+            .get_id()
+            .as_deref(),
+        Some("dest-a")
+    );
+    let (moving_audio_track, moving_audio_index, moving_audio_item) =
+        stack.get_item(&moving_audio_id).unwrap();
+    let (existing_audio_track, existing_audio_index, existing_audio_item) =
+        stack.get_item(&existing_audio_id).unwrap();
+    assert_eq!(moving_audio_track, existing_audio_track);
+    assert_eq!(
+        stack.children[moving_audio_track].start_time_of_item(moving_audio_index),
+        0.0
+    );
+    assert_eq!(
+        stack.children[existing_audio_track].start_time_of_item(existing_audio_index),
+        3.0
+    );
+    assert_eq!(link_group_id(moving_audio_item), source_result.link_group_id);
+    assert_eq!(link_group_id(existing_audio_item), dest_result.link_group_id);
+}
+
+#[test]
 fn move_linked_video_creates_only_missing_destination_audio_tracks() {
     let mut stack = Stack::default();
     stack


### PR DESCRIPTION
## Summary

Fixes linked video moves into a destination video track that already has linked audio in its boundary.

When moving a linked video clip with Push, the move helper now reuses a destination audio boundary track that already matches the destination video track linked boundary, instead of requiring that audio range to be gap-backed and creating a new audio track.

## Impact

- Moving a linked video clip to another video track reuses the existing linked audio boundary track when the destination already has linked video/audio content.
- Existing linked content in that destination boundary is pushed as part of the move.
- New audio tracks are still created when no suitable destination boundary track exists.

## Validation

- cargo test -p tellers-timeline-core move_linked --test linked
- cargo test -p tellers-timeline-core
