### PR TITLE
Remove all-gap tracks during sanitize

### DIFF
--- a/tellers-timeline-core/src/sanitize.rs
+++ b/tellers-timeline-core/src/sanitize.rs
@@ -16,6 +16,16 @@ impl Track {
         self.remove_trailing_gap();
     }
 
+    pub(crate) fn sanitize_preserving_all_gap_track(&mut self) {
+        self.clamp_clips_to_available_ranges();
+        self.clamp_negative_durations();
+        self.remove_zero_length_items();
+        self.merge_adjacent_gaps();
+        if !self.items.iter().all(|item| matches!(item, Item::Gap(_))) {
+            self.remove_trailing_gap();
+        }
+    }
+
     pub(crate) fn clamp_clips_to_available_ranges(&mut self) {
         for it in &mut self.items {
             it.clamp_to_active_available_range();
@@ -53,9 +63,6 @@ impl Track {
     }
 
     pub(crate) fn remove_trailing_gap(&mut self) {
-        if self.items.iter().all(|item| matches!(item, Item::Gap(_))) {
-            return;
-        }
         if self
             .items
             .last()
@@ -70,6 +77,14 @@ impl Stack {
     pub fn sanitize(&mut self) {
         for t in &mut self.children {
             t.sanitize();
+        }
+        self.ensure_unique_timeline_ids();
+        self.cleanup_dangling_link_groups();
+    }
+
+    pub(crate) fn sanitize_preserving_all_gap_tracks(&mut self) {
+        for t in &mut self.children {
+            t.sanitize_preserving_all_gap_track();
         }
         self.ensure_unique_timeline_ids();
         self.cleanup_dangling_link_groups();

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -1118,7 +1118,7 @@ impl Stack {
                 return false;
             }
             track.items.remove(item_index);
-            track.sanitize();
+            track.sanitize_preserving_all_gap_track();
         }
 
         for (_, track_index, start, item) in items {
@@ -1464,7 +1464,7 @@ impl Stack {
                 return false;
             };
             item.set_duration(new_duration.max(0.0));
-            track.sanitize();
+            track.sanitize_preserving_all_gap_track();
             if !self.sync_changed_link_groups_after_resize(
                 &before_states,
                 &[selected_track_index],
@@ -1474,7 +1474,7 @@ impl Stack {
                 *self = backup;
                 return false;
             }
-            self.sanitize();
+            self.sanitize_preserving_all_gap_tracks();
             return true;
         }
         let excluded_ids: HashSet<_> = target_ids.iter().cloned().collect();
@@ -1511,7 +1511,7 @@ impl Stack {
                 if clamp_to_media {
                     item.clamp_to_active_available_range();
                 }
-                track.sanitize();
+                track.sanitize_preserving_all_gap_track();
                 modified_track_indices.push(track_index);
             }
             modified_track_indices.sort_unstable();
@@ -1525,7 +1525,7 @@ impl Stack {
                 *self = backup;
                 return false;
             }
-            self.sanitize();
+            self.sanitize_preserving_all_gap_tracks();
             return true;
         }
 
@@ -1561,7 +1561,7 @@ impl Stack {
                 return false;
             }
             track.items.remove(item_index);
-            track.sanitize();
+            track.sanitize_preserving_all_gap_track();
         }
 
         for (track_index, target_start, item) in resized_items {
@@ -1587,7 +1587,7 @@ impl Stack {
             *self = backup;
             return false;
         }
-        self.sanitize();
+        self.sanitize_preserving_all_gap_tracks();
         true
     }
 
@@ -1615,7 +1615,7 @@ impl Stack {
             let replace_with_gap =
                 !matches!(self.children[track_index].items[item_index], Item::Gap(_));
             self.delete_item(item_id, replace_with_gap);
-            self.sanitize();
+            self.sanitize_preserving_all_gap_tracks();
             return true;
         }
 
@@ -1637,7 +1637,7 @@ impl Stack {
             let backup = self.clone();
             let before_states = self.linked_clip_states();
             self.children[track_index].items[item_index].set_duration(effective_duration);
-            self.sanitize();
+            self.sanitize_preserving_all_gap_tracks();
             if !self.sync_changed_link_groups_after_resize(
                 &before_states,
                 &[track_index],
@@ -1658,7 +1658,7 @@ impl Stack {
                     source_delta,
                     effective_duration,
                 );
-                self.sanitize();
+                self.sanitize_preserving_all_gap_tracks();
                 return true;
             }
 
@@ -1666,7 +1666,7 @@ impl Stack {
             if !resize_from_start && duration_delta > 0.0 {
                 let targets = self.linked_clip_targets_for_item(item_id);
                 self.resize_linked_clips_with_trailing_gap(targets, effective_duration);
-                self.sanitize();
+                self.sanitize_preserving_all_gap_tracks();
                 return true;
             }
         }
@@ -1690,7 +1690,7 @@ impl Stack {
             },
             clamp_to_media,
         );
-        self.sanitize();
+        self.sanitize_preserving_all_gap_tracks();
         resized
     }
 
@@ -2147,7 +2147,7 @@ impl Stack {
             return false;
         }
 
-        self.sanitize();
+        self.sanitize_preserving_all_gap_tracks();
         true
     }
 }

--- a/tellers-timeline-core/src/stack_methods/stack_item_insert.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_item_insert.rs
@@ -48,7 +48,7 @@ impl Stack {
             overlap_policy,
             insert_policy,
         );
-        self.sanitize();
+        self.sanitize_preserving_all_gap_tracks();
         Some(InsertItemAtTimeResult::ItemId(inserted_id))
     }
 
@@ -96,7 +96,7 @@ impl Stack {
         let mut used_ids = self.collect_timeline_ids();
         let inserted_id = Self::ensure_unique_item_id(&mut item, &mut used_ids);
         self.children[dest_track_index].insert_at_index(dest_index, item, overlap_policy);
-        self.sanitize();
+        self.sanitize_preserving_all_gap_tracks();
         Some(InsertItemAtTimeResult::ItemId(inserted_id))
     }
 }

--- a/tellers-timeline-core/src/stack_methods/stack_item_replace.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_item_replace.rs
@@ -209,7 +209,7 @@ impl Stack {
                     }
                 }
             }
-            self.sanitize();
+            self.sanitize_preserving_all_gap_tracks();
             return true;
         };
 
@@ -340,7 +340,7 @@ impl Stack {
             }
         }
 
-        self.sanitize();
+        self.sanitize_preserving_all_gap_tracks();
         true
     }
 }

--- a/tellers-timeline-core/src/stack_methods/stack_track.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_track.rs
@@ -122,7 +122,7 @@ impl Stack {
         for link_group_id in touched_link_groups {
             self.delete_link_group(link_group_id, true);
         }
-        self.sanitize();
+        self.sanitize_preserving_all_gap_tracks();
         Some(removed)
     }
 

--- a/tellers-timeline-core/src/track_methods/track_item_insert.rs
+++ b/tellers-timeline-core/src/track_methods/track_item_insert.rs
@@ -50,7 +50,7 @@ impl Track {
 
         if item.duration() <= EPS {
             self.items.insert(insert_index, item);
-            self.sanitize();
+            self.sanitize_preserving_all_gap_track();
             return;
         }
 
@@ -85,7 +85,7 @@ impl Track {
         }
 
         self.items.insert(insert_index, item);
-        self.sanitize();
+        self.sanitize_preserving_all_gap_track();
     }
 
     /// Insert an item at a timeline time, controlling how overlaps are handled
@@ -117,7 +117,7 @@ impl Track {
             self.items
                 .push(Item::Gap(crate::types::Gap::make_gap(gap_duration)));
             self.items.push(item);
-            self.sanitize();
+            self.sanitize_preserving_all_gap_track();
             return;
         }
 

--- a/tellers-timeline-core/tests/sanitize.rs
+++ b/tellers-timeline-core/tests/sanitize.rs
@@ -119,6 +119,26 @@ fn stack_sanitize_removes_track_trailing_gap_after_merging() {
 }
 
 #[test]
+fn stack_sanitize_removes_all_gap_track_items() {
+    let mut single_gap = Track::new(TrackKind::Video, Some("single-gap".to_string()));
+    single_gap.items.push(Item::Gap(Gap::make_gap(1.0)));
+
+    let mut adjacent_gaps = Track::new(TrackKind::Audio, Some("adjacent-gaps".to_string()));
+    adjacent_gaps.items.push(Item::Gap(Gap::make_gap(1.0)));
+    adjacent_gaps.items.push(Item::Gap(Gap::make_gap(2.0)));
+
+    let mut stack = Stack {
+        children: vec![single_gap, adjacent_gaps],
+        ..Stack::default()
+    };
+
+    stack.sanitize();
+
+    assert!(stack.children[0].items.is_empty());
+    assert!(stack.children[1].items.is_empty());
+}
+
+#[test]
 fn stack_sanitize_keeps_track_interior_gap() {
     let mut track = Track::new(TrackKind::Video, Some("video".to_string()));
     track.items.push(Item::Clip(clip(1.0, Some("clip-1"))));


### PR DESCRIPTION
## Summary

- Remove the all-gap exemption in explicit stack sanitization so a trailing gap is always removed.
- Add coverage for tracks containing only one gap or adjacent gaps.
- Keep internal stack editing operations on a preserving sanitizer path so linked boundary placeholder gaps remain intact during mutations.

## Why

sanitize already merged adjacent gaps and removed trailing gaps, but all-gap tracks were explicitly skipped. That left Gap and Gap, Gap tracks behind after explicit sanitization.

Some linked editing operations use gap-only tracks as boundary placeholders, so those internal mutation paths now use a private preserving sanitizer while public sanitize keeps the stricter cleanup behavior.

## Validation

- cargo test -p tellers-timeline-core