### PR TITLE
fix: default clip position to (0, 0) center in Resolve pan/tilt space

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -223,7 +223,7 @@ struct PyMediaReferencePosition {
 #[pymethods]
 impl PyMediaReferencePosition {
     #[new]
-    #[pyo3(signature = (x=0.5, y=0.5, rotation=0.0, zoom_x=1.0, zoom_y=1.0))]
+    #[pyo3(signature = (x=0.0, y=0.0, rotation=0.0, zoom_x=1.0, zoom_y=1.0))]
     fn new(x: f64, y: f64, rotation: f64, zoom_x: f64, zoom_y: f64) -> Self {
         Self {
             inner: MediaReferencePosition {

--- a/bindings/python/tests/test_position_volume.py
+++ b/bindings/python/tests/test_position_volume.py
@@ -9,10 +9,10 @@ def test_get_set_position():
     ref = MediaReference("file:///test.mp4")
     clip = Clip(10.0, {"DEFAULT_MEDIA": ref}, "DEFAULT_MEDIA")
 
-    # Get initial position (should have defaults)
+    # Get initial position (should have defaults: (0, 0) center in Resolve pan/tilt space)
     pos = clip.get_position()
-    assert pos.get_x() == 0.5
-    assert pos.get_y() == 0.5
+    assert pos.get_x() == 0.0
+    assert pos.get_y() == 0.0
     assert pos.get_rotation() == 0.0
     assert pos.get_zoom_x() == 1.0
     assert pos.get_zoom_y() == 1.0

--- a/tellers-timeline-core/src/types.rs
+++ b/tellers-timeline-core/src/types.rs
@@ -456,8 +456,10 @@ impl Clip {
 
     pub fn get_position(&self) -> MediaReferencePosition {
         let active_media_reference = self.media_references.get(self.active_media_reference_key.as_ref().unwrap()).unwrap();
-        let mut x = 0.5;
-        let mut y = 0.5;
+        // MediaReferencePosition uses [-0.5, +0.5] with (0, 0) at the screen center,
+        // matching Resolve's transformationPan/Tilt space where 0 is centered.
+        let mut x = 0.0;
+        let mut y = 0.0;
         let mut rotation = 0.0;
         let mut zoom_x = 1.0;
         let mut zoom_y = 1.0;

--- a/tellers-timeline-core/tests/position.rs
+++ b/tellers-timeline-core/tests/position.rs
@@ -1,0 +1,123 @@
+use std::collections::HashMap;
+use tellers_timeline_core::*;
+
+fn make_video_clip() -> Clip {
+    let mut refs: HashMap<String, MediaReference> = HashMap::new();
+    refs.insert(
+        "DEFAULT_MEDIA".to_string(),
+        MediaReference::ExternalReference {
+            target_url: "mem://".to_string(),
+            available_range: Some(TimeRange {
+                otio_schema: "TimeRange.1".to_string(),
+                duration: RationalTime { otio_schema: "RationalTime.1".to_string(), rate: 1.0, value: 10.0 },
+                start_time: RationalTime { otio_schema: "RationalTime.1".to_string(), rate: 1.0, value: 0.0 },
+            }),
+            name: None,
+            available_image_bounds: None,
+            metadata: serde_json::Value::Null,
+        },
+    );
+    Clip {
+        otio_schema: "Clip.2".to_string(),
+        enabled: true,
+        name: Some("c".to_string()),
+        source_range: TimeRange {
+            otio_schema: "TimeRange.1".to_string(),
+            duration: RationalTime { otio_schema: "RationalTime.1".to_string(), rate: 1.0, value: 10.0 },
+            start_time: RationalTime { otio_schema: "RationalTime.1".to_string(), rate: 1.0, value: 0.0 },
+        },
+        media_references: refs,
+        active_media_reference_key: Some("DEFAULT_MEDIA".to_string()),
+        metadata: serde_json::Value::Null,
+        effects: Vec::new(),
+    }
+}
+
+#[test]
+fn get_position_defaults_to_center_without_transform_effect() {
+    let clip = make_video_clip();
+    let pos = clip.get_position();
+    // Resolve pan/tilt space: 0.0 is the screen center.
+    assert_eq!(pos.x, 0.0);
+    assert_eq!(pos.y, 0.0);
+    assert_eq!(pos.rotation, 0.0);
+    assert_eq!(pos.zoom_x, 1.0);
+    assert_eq!(pos.zoom_y, 1.0);
+}
+
+#[test]
+fn get_position_defaults_to_center_with_empty_transform_parameters() {
+    // DaVinci Resolve exports untouched clips with a Transform effect whose
+    // Parameters array is empty; absent parameters mean Resolve defaults
+    // (pan = 0, tilt = 0 → centered).
+    let json = r#"
+    {
+        "OTIO_SCHEMA": "Clip.2",
+        "name": "Resolve Clip",
+        "source_range": {
+            "OTIO_SCHEMA": "TimeRange.1",
+            "start_time": { "OTIO_SCHEMA": "RationalTime.1", "rate": 30.0, "value": 0.0 },
+            "duration": { "OTIO_SCHEMA": "RationalTime.1", "rate": 30.0, "value": 100.0 }
+        },
+        "media_references": {
+            "DEFAULT_MEDIA": {
+                "OTIO_SCHEMA": "ExternalReference.1",
+                "metadata": {},
+                "name": "clip.mp4",
+                "available_range": null,
+                "available_image_bounds": null,
+                "target_url": "mem://clip.mp4"
+            }
+        },
+        "active_media_reference_key": "DEFAULT_MEDIA",
+        "metadata": {},
+        "effects": [
+            {
+                "OTIO_SCHEMA": "Effect.1",
+                "name": "",
+                "effect_name": "Resolve Effect",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Effect Name": "Transform",
+                        "Enabled": true,
+                        "Name": "Transform",
+                        "Parameters": [],
+                        "Type": 2
+                    }
+                }
+            }
+        ]
+    }
+    "#;
+    let clip: Clip = serde_json::from_str(json).expect("Failed to parse clip");
+    let pos = clip.get_position();
+    assert_eq!(pos.x, 0.0);
+    assert_eq!(pos.y, 0.0);
+}
+
+#[test]
+fn position_get_set_round_trip_keeps_clip_centered() {
+    // Regression for tellers-app#2253: saving and restoring the position of a
+    // default (centered) clip must not write a pan/tilt offset.
+    let mut clip = make_video_clip();
+    let saved = clip.get_position();
+    clip.set_position(saved);
+
+    let pos = clip.get_position();
+    assert_eq!(pos.x, 0.0);
+    assert_eq!(pos.y, 0.0);
+
+    // The written Transform effect must store pan/tilt 0 (Resolve center).
+    let transform = clip
+        .effects
+        .iter()
+        .find_map(|e| e.metadata.resolve_otio.as_ref())
+        .expect("set_position should create a Transform effect");
+    for parameter in &transform.parameters {
+        if let ResolveOTIOParameter::Double(param) = parameter {
+            if param.parameter_id == "transformationPan" || param.parameter_id == "transformationTilt" {
+                assert_eq!(param.parameter_value, 0.0, "{} must stay centered", param.parameter_id);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `Clip::get_position()` fell back to `(0.5, 0.5)` when a clip had no Transform effect, while `set_position()` writes `x`/`y` verbatim into `transformationPan`/`transformationTilt` — where **0 is the screen center** (Resolve convention). The get→set round trip was therefore not idempotent: any code that saved a default clip's position and restored it (e.g. the backend sanitiser cropping an overlong clip) wrote `pan=0.5, tilt=0.5`, shifting the clip down-right by half the frame. This is the root cause of undisclosed-team/tellers-app#2253.
- The same wrong fallback also corrupts genuine DaVinci Resolve OTIO files: Resolve exports untouched clips with a Transform effect whose `Parameters` array is **empty**, so those clips read back as `(0.5, 0.5)` too.
- Verified against real Resolve exports: Resolve declares `"Default Parameter Value": 0.0` for both `transformationPan` and `transformationTilt` (range ±4.0), i.e. 0 = centered, normalized by frame width/height. This also matches the Tellers API convention documented in the backend agent prompt ((0,0) = center, [-0.5, +0.5] range) and the video-player's rendering math.

## Changes

- `tellers-timeline-core/src/types.rs`: `get_position()` fallback `(0.5, 0.5)` → `(0.0, 0.0)`.
- `bindings/python/src/lib.rs`: `MediaReferencePosition` constructor defaults `x=0.5, y=0.5` → `x=0.0, y=0.0`.
- New regression tests (`tests/position.rs`): default position without Transform effect, default with Resolve-style empty `Parameters`, and get→set round-trip idempotence.

Note: this supersedes the approach in undisclosed-team/tellers-backend#1097, which added ±0.5 conversion in the backend on the assumption that the API space uses 0.5 = center — that conflicts with the documented agent convention and would mis-read clips from real Resolve exports. The backend's own 0.5 insert/edit defaults are fixed in a companion PR.

## Test plan

- [x] `cargo test -p tellers-timeline-core` — all suites pass, including 3 new regression tests
- [x] `cargo check` on the Python bindings
- [ ] Re-run the #2253 repro: sanitise an overlong centered clip → no Transform pan/tilt offset in the exported OTIO

🤖 Generated with [Claude Code](https://claude.com/claude-code)