### PR TITLE
Fix resize overwrite semantics

### DIFF
--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -1493,6 +1493,67 @@ impl Stack {
 
         let backup = self.clone();
         if start_delta.abs() <= EPS {
+            if overlap_policy != OverlapPolicy::Push {
+                let mut resized_items = Vec::new();
+                let mut modified_track_indices = Vec::new();
+
+                for id in &target_ids {
+                    let Some((track_index, item_index, item)) = self.get_item(id) else {
+                        *self = backup;
+                        return false;
+                    };
+                    if matches!(item, Item::Gap(_)) {
+                        resized_items.clear();
+                        modified_track_indices.clear();
+                        break;
+                    }
+
+                    let old_start = self.children[track_index].start_time_of_item(item_index);
+                    let old_duration = item.duration().max(0.0);
+                    if effective_duration <= old_duration + EPS {
+                        resized_items.clear();
+                        modified_track_indices.clear();
+                        break;
+                    }
+
+                    let mut item = item.clone();
+                    item.set_duration(effective_duration);
+                    if clamp_to_media {
+                        item.clamp_to_active_available_range();
+                    }
+                    resized_items.push((
+                        track_index,
+                        old_start,
+                        old_start + effective_duration,
+                        item,
+                    ));
+                    modified_track_indices.push(track_index);
+                }
+
+                if !resized_items.is_empty() {
+                    for (track_index, range_start, range_end, item) in resized_items {
+                        let Some(track) = self.children.get_mut(track_index) else {
+                            *self = backup;
+                            return false;
+                        };
+                        replace_track_range_with_item(track, range_start, range_end, item);
+                    }
+                    modified_track_indices.sort_unstable();
+                    modified_track_indices.dedup();
+                    if !self.sync_changed_link_groups_after_resize(
+                        &before_states,
+                        &modified_track_indices,
+                        &excluded_ids,
+                        overlap_policy,
+                    ) {
+                        *self = backup;
+                        return false;
+                    }
+                    self.sanitize_preserving_all_gap_tracks();
+                    return true;
+                }
+            }
+
             let mut modified_track_indices = Vec::new();
             for id in &target_ids {
                 let Some((track_index, item_index, _)) = self.get_item(id) else {

--- a/tellers-timeline-core/tests/linked.rs
+++ b/tellers-timeline-core/tests/linked.rs
@@ -4536,7 +4536,7 @@ fn resize_audio_linked_item_push_updates_video_and_following_group() {
 }
 
 #[test]
-fn resize_audio_linked_item_override_preserves_following_group_when_start_is_unchanged() {
+fn resize_audio_linked_item_override_trims_following_group_when_start_is_unchanged() {
     let mut stack = Stack::default();
     stack
         .children
@@ -4571,13 +4571,12 @@ fn resize_audio_linked_item_override_preserves_following_group_when_start_is_unc
         );
         assert_eq!(item.duration(), 3.0);
     }
-    for item_id in ["second-video", &second_audio_id] {
-        let (track_index, item_index, item) = stack.get_item(item_id).unwrap();
-        assert_eq!(
-            stack.children[track_index].start_time_of_item(item_index),
-            3.0
-        );
-        assert_eq!(item.duration(), 2.0);
+    assert!(stack.get_item("second-video").is_none());
+    assert!(stack.get_item(&second_audio_id).is_none());
+    for track in &stack.children {
+        assert_eq!(track.items.len(), 2);
+        assert_eq!(track.start_time_of_item(1), 3.0);
+        assert_eq!(track.items[1].duration(), 1.0);
     }
 }
 

--- a/tellers-timeline-core/tests/resize.rs
+++ b/tellers-timeline-core/tests/resize.rs
@@ -255,7 +255,7 @@ fn modify_gap_to_negative_duration_removes_gap() {
 }
 
 #[test]
-fn resize_audio_clip_duration_preserves_following_clip() {
+fn resize_audio_clip_extension_overrides_following_clip() {
     let mut track = Track::new(TrackKind::Audio, Some("a".to_string()));
     let mut first = make_clip(2.0, 0.0);
     first.set_id(Some("first".to_string()));
@@ -271,17 +271,44 @@ fn resize_audio_clip_duration_preserves_following_clip() {
     assert!(stack.resize_item("first", 0.0, 4.0, OverlapPolicy::Override, false));
 
     let (first_track_index, first_item_index, first_item) = stack.get_item("first").unwrap();
-    let (second_track_index, second_item_index, second_item) = stack.get_item("second").unwrap();
+    let second_item_index = 1;
+    let second_item = &stack.children[first_track_index].items[second_item_index];
     assert_eq!(first_track_index, 0);
-    assert_eq!(second_track_index, 0);
     assert_eq!(first_item_index, 0);
-    assert_eq!(second_item_index, 1);
     assert_eq!(first_item.duration(), 4.0);
-    assert_eq!(second_item.duration(), 3.0);
+    assert_eq!(second_item.duration(), 1.0);
     assert_eq!(
-        stack.children[second_track_index].start_time_of_item(second_item_index),
+        stack.children[first_track_index].start_time_of_item(second_item_index),
         4.0
     );
+}
+
+#[test]
+fn modify_clip_right_extension_overrides_following_clip() {
+    let mut track = Track::new(TrackKind::Video, Some("v".to_string()));
+    let mut first = make_clip(2.0, 0.0);
+    first.set_id(Some("first".to_string()));
+    let mut second = make_clip(3.0, 0.0);
+    second.set_id(Some("second".to_string()));
+    track.items.push(first);
+    track.items.push(second);
+    let mut stack = Stack {
+        children: vec![track],
+        ..Stack::default()
+    };
+
+    assert!(stack.modify_item("first", 0.0, 4.0, false, false, false));
+
+    let track = &stack.children[0];
+    assert_eq!(track.items.len(), 2);
+    let (first_track_index, first_item_index, first_item) = stack.get_item("first").unwrap();
+    let second_item_index = 1;
+    let second_item = &track.items[second_item_index];
+    assert_eq!(first_track_index, 0);
+    assert_eq!(first_item_index, 0);
+    assert_eq!(first_item.duration(), 4.0);
+    assert_eq!(second_item.duration(), 1.0);
+    assert_eq!(track.start_time_of_item(second_item_index), 4.0);
 }
 
 #[test]
@@ -301,11 +328,8 @@ fn resize_item_sets_rational_time_duration_from_seconds() {
     assert!(stack.resize_item("first", 0.0, 3.0, OverlapPolicy::Override, false));
 
     let (first_track_index, first_item_index, first_item) = stack.get_item("first").unwrap();
-    let (second_track_index, second_item_index, _) = stack.get_item("second").unwrap();
-    assert_eq!(
-        stack.children[second_track_index].start_time_of_item(second_item_index),
-        3.0
-    );
+    assert!(stack.get_item("second").is_none());
+    assert_eq!(stack.children[first_track_index].items.len(), 1);
     match &stack.children[first_track_index].items[first_item_index] {
         Item::Clip(clip) => {
             assert_eq!(clip.source_range.duration.rate, 24.0);
@@ -402,20 +426,8 @@ fn resize_overshoot_with_clamp_uses_clip_rate_not_media_rate() {
         _ => panic!("expected clip"),
     }
 
-    let (following_track_index, following_item_index, following_item) =
-        stack.get_item("following").unwrap();
-    assert_eq!(
-        stack.children[following_track_index].start_time_of_item(following_item_index),
-        5.0
-    );
-    assert_eq!(following_item.duration(), 3.0);
-    match &stack.children[following_track_index].items[following_item_index] {
-        Item::Clip(clip) => {
-            assert_eq!(clip.source_range.duration.rate, 30.0);
-            assert_eq!(clip.source_range.duration.value, 90.0);
-        }
-        _ => panic!("expected following clip"),
-    }
+    assert!(stack.get_item("following").is_none());
+    assert_eq!(stack.children[track_index].items.len(), 1);
 }
 
 #[test]

--- a/tellers-timeline-core/tests/resize.rs
+++ b/tellers-timeline-core/tests/resize.rs
@@ -312,6 +312,37 @@ fn modify_clip_right_extension_overrides_following_clip() {
 }
 
 #[test]
+fn modify_clip_right_extension_overrides_multiple_following_clips() {
+    let mut track = Track::new(TrackKind::Video, Some("v".to_string()));
+    let mut first = make_clip(2.0, 0.0);
+    first.set_id(Some("first".to_string()));
+    let mut second = make_clip(3.0, 0.0);
+    second.set_id(Some("second".to_string()));
+    let mut third = make_clip(4.0, 0.0);
+    third.set_id(Some("third".to_string()));
+    track.items.push(first);
+    track.items.push(second);
+    track.items.push(third);
+    let mut stack = Stack {
+        children: vec![track],
+        ..Stack::default()
+    };
+
+    assert!(stack.modify_item("first", 0.0, 7.0, false, false, false));
+
+    let track = &stack.children[0];
+    assert_eq!(track.items.len(), 2);
+    let (first_track_index, first_item_index, first_item) = stack.get_item("first").unwrap();
+    let third_item_index = 1;
+    let third_item = &track.items[third_item_index];
+    assert_eq!(first_track_index, 0);
+    assert_eq!(first_item_index, 0);
+    assert_eq!(first_item.duration(), 7.0);
+    assert_eq!(third_item.duration(), 2.0);
+    assert_eq!(track.start_time_of_item(third_item_index), 7.0);
+}
+
+#[test]
 fn resize_item_sets_rational_time_duration_from_seconds() {
     let mut track = Track::new(TrackKind::Audio, Some("a".to_string()));
     let mut first = make_clip_with_rate(2.0, 0.0, 24.0);


### PR DESCRIPTION
## Summary
- Make unchanged-start override resizes overwrite following clips instead of preserving and pushing them
- Keep push resizes and gap-specific resize behavior unchanged
- Add regressions for direct resize, modify-item resize, and linked audio/video groups

## Tests
- cargo test -p tellers-timeline-core
- cargo test in tellers-app/rust with tellers-timeline-core pointed at this local checkout