### PR TITLE
Rework delete_item sync track cluster algorithm

### DIFF
--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -553,6 +553,219 @@ impl Stack {
         Some(group_start)
     }
 
+    fn item_occupies_column(
+        &self,
+        track_index: usize,
+        item_index: usize,
+        column_start: Seconds,
+        column_duration: Seconds,
+    ) -> bool {
+        let Some(track) = self.children.get(track_index) else {
+            return false;
+        };
+        if item_index >= track.items.len() {
+            return false;
+        }
+        (track.start_time_of_item(item_index) - column_start).abs() <= EPS
+            && (track.items[item_index].duration() - column_duration).abs() <= EPS
+    }
+
+    fn has_sync_or_target_item_at_column(
+        &self,
+        track_index: usize,
+        item_id: &str,
+        column_start: Seconds,
+        column_duration: Seconds,
+        sync_clips_id: Option<i64>,
+    ) -> bool {
+        let Some(track) = self.children.get(track_index) else {
+            return false;
+        };
+        let Some(item_index) = track.get_item_at_time(column_start) else {
+            return false;
+        };
+        if !self.item_occupies_column(track_index, item_index, column_start, column_duration) {
+            return false;
+        }
+        let item = &track.items[item_index];
+        if item.get_id().as_deref() == Some(item_id) {
+            return true;
+        }
+        if let (Item::Clip(clip), Some(sync_id)) = (item, sync_clips_id) {
+            return resolve_sync_clips_id(&clip.metadata) == Some(sync_id);
+        }
+        false
+    }
+
+    fn delete_item_replace_with_gap(
+        &mut self,
+        item_id: &str,
+        track_index: usize,
+        item_index: usize,
+        cluster: &[usize],
+        column_start: Seconds,
+        column_duration: Seconds,
+        sync_clips_id: Option<i64>,
+    ) -> Vec<(usize, Item)> {
+        if column_duration <= EPS {
+            let removed = self
+                .delete_one_item(item_id, false)
+                .into_iter()
+                .collect::<Vec<_>>();
+            if !removed.is_empty() {
+                self.sanitize();
+            }
+            return removed;
+        }
+
+        let column_end = column_start + column_duration;
+        let mut removed = Vec::new();
+        let mut used_ids = self.collect_timeline_ids();
+        let mut replacements = Vec::new();
+
+        if let Some(sync_id) = sync_clips_id {
+            for (ti, ii) in self.synced_clips_targets(sync_id) {
+                if self.item_occupies_column(ti, ii, column_start, column_duration) {
+                    replacements.push((ti, ii));
+                }
+            }
+        } else {
+            replacements.push((track_index, item_index));
+        }
+
+        let pad_cluster = sync_clips_id.is_some()
+            || self.is_cluster_column_at(cluster, column_start, column_duration);
+        if pad_cluster {
+            for &ti in cluster {
+                if replacements.iter().any(|(t, _)| *t == ti) {
+                    continue;
+                }
+                if range_is_gap_backed(&self.children[ti], column_start, column_end) {
+                    let mut gap = Item::Gap(Gap::make_gap(column_duration));
+                    Self::ensure_unique_item_id(&mut gap, &mut used_ids);
+                    let _ = self.insert_gap_only(ti, column_start, gap);
+                }
+            }
+        }
+
+        replacements.sort_by(|a, b| b.cmp(a));
+        replacements.dedup();
+        for (ti, ii) in replacements {
+            if ti >= self.children.len() || ii >= self.children[ti].items.len() {
+                continue;
+            }
+            let removed_item = self.children[ti].items.remove(ii);
+            removed.push((ti, removed_item));
+            let mut gap = Item::Gap(Gap::make_gap(column_duration));
+            Self::ensure_unique_item_id(&mut gap, &mut used_ids);
+            self.children[ti].items.insert(ii, gap);
+            self.children[ti].merge_adjacent_gaps();
+        }
+
+        removed.reverse();
+        self.sanitize();
+        removed
+    }
+
+    fn delete_item_collapse(
+        &mut self,
+        item_id: &str,
+        cluster: &[usize],
+        column_start: Seconds,
+        column_duration: Seconds,
+        sync_clips_id: Option<i64>,
+    ) -> Vec<(usize, Item)> {
+        if column_duration <= EPS {
+            let removed = self
+                .delete_one_item(item_id, false)
+                .into_iter()
+                .collect::<Vec<_>>();
+            if !removed.is_empty() {
+                self.sanitize();
+            }
+            return removed;
+        }
+
+        let column_end = column_start + column_duration;
+        let backup = self.clone();
+        let mut removed = Vec::new();
+        let mut used_ids = self.collect_timeline_ids();
+
+        for &ti in cluster {
+            if self.has_sync_or_target_item_at_column(
+                ti,
+                item_id,
+                column_start,
+                column_duration,
+                sync_clips_id,
+            ) {
+                continue;
+            }
+            let mut gap = Item::Gap(Gap::make_gap(column_duration));
+            Self::ensure_unique_item_id(&mut gap, &mut used_ids);
+            if !self.insert_gap_only(ti, column_start, gap)
+                && !range_is_gap_backed(&self.children[ti], column_start, column_end)
+            {
+                *self = backup;
+                return Vec::new();
+            }
+        }
+
+        let mut to_remove = Vec::new();
+        for &ti in cluster {
+            let Some(track) = self.children.get(ti) else {
+                continue;
+            };
+            let Some(ii) = track.get_item_at_time(column_start) else {
+                continue;
+            };
+            if !self.item_occupies_column(ti, ii, column_start, column_duration) {
+                continue;
+            }
+            let item = &track.items[ii];
+            let is_target = item.get_id().as_deref() == Some(item_id);
+            let is_synced = sync_clips_id.is_some_and(|sync_id| {
+                matches!(
+                    item,
+                    Item::Clip(clip) if resolve_sync_clips_id(&clip.metadata) == Some(sync_id)
+                )
+            });
+            if is_target || is_synced {
+                to_remove.push((ti, ii));
+            }
+        }
+
+        to_remove.sort_by(|a, b| b.cmp(a));
+        to_remove.dedup();
+        let mut collapsed_tracks = HashSet::new();
+        for (ti, ii) in to_remove {
+            if ti >= self.children.len() || ii >= self.children[ti].items.len() {
+                continue;
+            }
+            let removed_item = self.children[ti].items.remove(ii);
+            removed.push((ti, removed_item));
+            collapsed_tracks.insert(ti);
+            self.children[ti].sanitize_preserving_all_gap_track();
+        }
+
+        for &ti in cluster {
+            if collapsed_tracks.contains(&ti) {
+                continue;
+            }
+            let Some(track) = self.children.get_mut(ti) else {
+                continue;
+            };
+            if !remove_gap_range(track, column_start, column_end) {
+                *self = backup;
+                return Vec::new();
+            }
+            track.sanitize_preserving_all_gap_track();
+        }
+
+        self.sanitize();
+        removed
+    }
+
     fn delete_sync_clips(
         &mut self,
         sync_clips_id: i64,
@@ -2520,6 +2733,34 @@ impl Stack {
         self.sanitize_preserving_all_gap_tracks();
         true
     }
+}
+
+pub(super) fn remove_gap_range(track: &mut Track, start: Seconds, end: Seconds) -> bool {
+    if !range_is_gap_backed(track, start, end) {
+        return false;
+    }
+
+    split_gap_boundary(track, end);
+    split_gap_boundary(track, start);
+
+    let mut pos = 0.0;
+    let mut index = 0;
+    while index < track.items.len() {
+        let duration = track.items[index].duration().max(0.0);
+        let item_start = pos;
+        let item_end = pos + duration;
+        if item_start >= start - EPS && item_end <= end + EPS {
+            if !matches!(track.items[index], Item::Gap(_)) {
+                return false;
+            }
+            track.items.remove(index);
+            pos = item_end;
+        } else {
+            pos = item_end;
+            index += 1;
+        }
+    }
+    true
 }
 
 pub(super) fn range_is_gap_backed(track: &Track, start: Seconds, end: Seconds) -> bool {

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -570,31 +570,16 @@ impl Stack {
             && (track.items[item_index].duration() - column_duration).abs() <= EPS
     }
 
-    fn has_sync_or_target_item_at_column(
+    fn item_at_column(
         &self,
         track_index: usize,
-        item_id: &str,
         column_start: Seconds,
         column_duration: Seconds,
-        sync_clips_id: Option<i64>,
-    ) -> bool {
-        let Some(track) = self.children.get(track_index) else {
-            return false;
-        };
-        let Some(item_index) = track.get_item_at_time(column_start) else {
-            return false;
-        };
-        if !self.item_occupies_column(track_index, item_index, column_start, column_duration) {
-            return false;
-        }
-        let item = &track.items[item_index];
-        if item.get_id().as_deref() == Some(item_id) {
-            return true;
-        }
-        if let (Item::Clip(clip), Some(sync_id)) = (item, sync_clips_id) {
-            return resolve_sync_clips_id(&clip.metadata) == Some(sync_id);
-        }
-        false
+    ) -> Option<usize> {
+        let track = self.children.get(track_index)?;
+        let item_index = track.get_item_at_time(column_start)?;
+        self.item_occupies_column(track_index, item_index, column_start, column_duration)
+            .then_some(item_index)
     }
 
     fn delete_clips_at_indices(
@@ -667,95 +652,92 @@ impl Stack {
         removed
     }
 
-    fn delete_item_collapse(
-        &mut self,
-        item_id: &str,
-        cluster: &[usize],
-        column_start: Seconds,
-        column_duration: Seconds,
-        sync_clips_id: Option<i64>,
-    ) -> Vec<(usize, Item)> {
-        if column_duration <= EPS {
-            let removed = self
-                .delete_one_item(item_id, false)
-                .into_iter()
-                .collect::<Vec<_>>();
+    fn delete_item_collapse(&mut self, item_id: &str) -> Vec<(usize, Item)> {
+        let Some((track_index, item_index, item)) = self.get_item(item_id) else {
+            return Vec::new();
+        };
+
+        if matches!(item, Item::Gap(_)) {
+            let removed = self.delete_clips_at_indices(vec![(track_index, item_index)], false);
             if !removed.is_empty() {
                 self.sanitize();
             }
             return removed;
         }
 
-        let column_end = column_start + column_duration;
-        let backup = self.clone();
-        let mut removed = Vec::new();
-        let mut used_ids = self.collect_timeline_ids();
-
-        for &ti in cluster {
-            if self.has_sync_or_target_item_at_column(
-                ti,
-                item_id,
-                column_start,
-                column_duration,
-                sync_clips_id,
-            ) {
-                continue;
+        if item.duration() <= EPS {
+            let removed: Vec<_> = self
+                .delete_one_item(item_id, false)
+                .into_iter()
+                .collect();
+            if !removed.is_empty() {
+                self.sanitize();
             }
-            let mut gap = Item::Gap(Gap::make_gap(column_duration));
-            Self::ensure_unique_item_id(&mut gap, &mut used_ids);
-            if !self.insert_gap_only(ti, column_start, gap)
-                && !range_is_gap_backed(&self.children[ti], column_start, column_end)
-            {
-                *self = backup;
-                return Vec::new();
-            }
+            return removed;
         }
 
-        let mut to_remove = Vec::new();
-        for &ti in cluster {
-            let Some(track) = self.children.get(ti) else {
+        let column_start = self.children[track_index].start_time_of_item(item_index);
+        let column_duration = item.duration().max(0.0);
+        let linked_tracks = self.boundary_group_indices(track_index);
+        let sync_clips_id = match &item {
+            Item::Clip(clip) => resolve_sync_clips_id(&clip.metadata),
+            Item::Gap(_) => None,
+        };
+
+        let backup = self.clone();
+        let mut clips_to_delete = Vec::new();
+        let mut covered_tracks = HashSet::new();
+
+        for &ti in &linked_tracks {
+            let Some(ii) = self.item_at_column(ti, column_start, column_duration) else {
                 continue;
             };
-            let Some(ii) = track.get_item_at_time(column_start) else {
-                continue;
-            };
-            if !self.item_occupies_column(ti, ii, column_start, column_duration) {
-                continue;
-            }
-            let item = &track.items[ii];
-            let is_target = item.get_id().as_deref() == Some(item_id);
+            let column_item = &self.children[ti].items[ii];
+            let is_target = column_item.get_id().as_deref() == Some(item_id);
             let is_synced = sync_clips_id.is_some_and(|sync_id| {
                 matches!(
-                    item,
+                    column_item,
                     Item::Clip(clip) if resolve_sync_clips_id(&clip.metadata) == Some(sync_id)
                 )
             });
             if is_target || is_synced {
-                to_remove.push((ti, ii));
+                clips_to_delete.push((ti, ii));
+                covered_tracks.insert(ti);
             }
         }
 
-        to_remove.sort_by(|a, b| b.cmp(a));
-        to_remove.dedup();
-        let removed_clips = self.delete_clips_at_indices(to_remove, false);
-        let collapsed_tracks: HashSet<usize> = removed_clips.iter().map(|(ti, _)| *ti).collect();
-        removed.extend(removed_clips);
-
-        for &ti in cluster {
-            if collapsed_tracks.contains(&ti) {
-                continue;
+        if covered_tracks.len() < linked_tracks.len() {
+            let mut used_ids = self.collect_timeline_ids();
+            for &ti in &linked_tracks {
+                if covered_tracks.contains(&ti) {
+                    continue;
+                }
+                if let Some(ii) = self.item_at_column(ti, column_start, column_duration) {
+                    if matches!(self.children[ti].items[ii], Item::Gap(_)) {
+                        clips_to_delete.push((ti, ii));
+                        covered_tracks.insert(ti);
+                        continue;
+                    }
+                }
+                let mut gap = Item::Gap(Gap::make_gap(column_duration));
+                Self::ensure_unique_item_id(&mut gap, &mut used_ids);
+                if !self.insert_gap_only(ti, column_start, gap) {
+                    *self = backup;
+                    return Vec::new();
+                }
+                let Some(ii) = self.item_at_column(ti, column_start, column_duration) else {
+                    *self = backup;
+                    return Vec::new();
+                };
+                clips_to_delete.push((ti, ii));
+                covered_tracks.insert(ti);
             }
-            let Some(track) = self.children.get_mut(ti) else {
-                continue;
-            };
-            if !remove_gap_range(track, column_start, column_end) {
-                *self = backup;
-                return Vec::new();
-            }
-            track.sanitize_preserving_all_gap_track();
         }
 
-        self.sanitize();
+        let removed = self.delete_clips_at_indices(clips_to_delete, false);
+        if !removed.is_empty() {
+            self.sanitize();
+        }
         removed
     }
 

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -597,73 +597,73 @@ impl Stack {
         false
     }
 
-    fn delete_item_replace_with_gap(
+    fn delete_clips_at_indices(
         &mut self,
-        item_id: &str,
-        track_index: usize,
-        item_index: usize,
-        cluster: &[usize],
-        column_start: Seconds,
-        column_duration: Seconds,
-        sync_clips_id: Option<i64>,
+        mut targets: Vec<(usize, usize)>,
+        replace_with_gap: bool,
     ) -> Vec<(usize, Item)> {
-        if column_duration <= EPS {
-            let removed = self
-                .delete_one_item(item_id, false)
-                .into_iter()
-                .collect::<Vec<_>>();
-            if !removed.is_empty() {
-                self.sanitize();
-            }
-            return removed;
-        }
-
-        let column_end = column_start + column_duration;
+        targets.sort_by(|a, b| b.cmp(a));
+        targets.dedup();
         let mut removed = Vec::new();
-        let mut used_ids = self.collect_timeline_ids();
-        let mut replacements = Vec::new();
-
-        if let Some(sync_id) = sync_clips_id {
-            for (ti, ii) in self.synced_clips_targets(sync_id) {
-                if self.item_occupies_column(ti, ii, column_start, column_duration) {
-                    replacements.push((ti, ii));
-                }
-            }
-        } else {
-            replacements.push((track_index, item_index));
-        }
-
-        let pad_cluster = sync_clips_id.is_some()
-            || self.is_cluster_column_at(cluster, column_start, column_duration);
-        if pad_cluster {
-            for &ti in cluster {
-                if replacements.iter().any(|(t, _)| *t == ti) {
-                    continue;
-                }
-                if range_is_gap_backed(&self.children[ti], column_start, column_end) {
-                    let mut gap = Item::Gap(Gap::make_gap(column_duration));
-                    Self::ensure_unique_item_id(&mut gap, &mut used_ids);
-                    let _ = self.insert_gap_only(ti, column_start, gap);
-                }
-            }
-        }
-
-        replacements.sort_by(|a, b| b.cmp(a));
-        replacements.dedup();
-        for (ti, ii) in replacements {
-            if ti >= self.children.len() || ii >= self.children[ti].items.len() {
+        let mut used_ids = replace_with_gap.then(|| self.collect_timeline_ids());
+        for (ti, ii) in targets {
+            if ti >= self.children.len() {
                 continue;
             }
-            let removed_item = self.children[ti].items.remove(ii);
+            let track = &mut self.children[ti];
+            if ii >= track.items.len() {
+                continue;
+            }
+            let removed_item = track.items[ii].clone();
+            if !track.delete_clip_at(ii, replace_with_gap) {
+                continue;
+            }
+            if replace_with_gap {
+                if let (Some(used_ids), Some(item)) = (&mut used_ids, track.items.get_mut(ii)) {
+                    if matches!(item, Item::Gap(_)) {
+                        Self::ensure_unique_item_id(item, used_ids);
+                    }
+                }
+            }
             removed.push((ti, removed_item));
-            let mut gap = Item::Gap(Gap::make_gap(column_duration));
-            Self::ensure_unique_item_id(&mut gap, &mut used_ids);
-            self.children[ti].items.insert(ii, gap);
-            self.children[ti].merge_adjacent_gaps();
         }
-
         removed.reverse();
-        self.sanitize();
+        removed
+    }
+
+    fn delete_item_targets(&self, item_id: &str) -> Option<Vec<(usize, usize)>> {
+        let (track_index, item_index, item) = self.get_item(item_id)?;
+        if matches!(item, Item::Gap(_)) {
+            return None;
+        }
+        let sync_clips_id = match &item {
+            Item::Clip(clip) => resolve_sync_clips_id(&clip.metadata),
+            Item::Gap(_) => None,
+        };
+        if let Some(sync_id) = sync_clips_id {
+            let column_start = self.children[track_index].start_time_of_item(item_index);
+            let column_duration = item.duration().max(0.0);
+            Some(
+                self.synced_clips_targets(sync_id)
+                    .into_iter()
+                    .filter(|(ti, ii)| {
+                        self.item_occupies_column(*ti, *ii, column_start, column_duration)
+                    })
+                    .collect(),
+            )
+        } else {
+            Some(vec![(track_index, item_index)])
+        }
+    }
+
+    fn delete_item_replace_with_gap(&mut self, item_id: &str) -> Vec<(usize, Item)> {
+        let Some(targets) = self.delete_item_targets(item_id) else {
+            return Vec::new();
+        };
+        let removed = self.delete_clips_at_indices(targets, true);
+        if !removed.is_empty() {
+            self.sanitize();
+        }
         removed
     }
 
@@ -737,16 +737,9 @@ impl Stack {
 
         to_remove.sort_by(|a, b| b.cmp(a));
         to_remove.dedup();
-        let mut collapsed_tracks = HashSet::new();
-        for (ti, ii) in to_remove {
-            if ti >= self.children.len() || ii >= self.children[ti].items.len() {
-                continue;
-            }
-            let removed_item = self.children[ti].items.remove(ii);
-            removed.push((ti, removed_item));
-            collapsed_tracks.insert(ti);
-            self.children[ti].sanitize_preserving_all_gap_track();
-        }
+        let removed_clips = self.delete_clips_at_indices(to_remove, false);
+        let collapsed_tracks: HashSet<usize> = removed_clips.iter().map(|(ti, _)| *ti).collect();
+        removed.extend(removed_clips);
 
         for &ti in cluster {
             if collapsed_tracks.contains(&ti) {
@@ -771,36 +764,7 @@ impl Stack {
         sync_clips_id: i64,
         replace_with_gap: bool,
     ) -> Vec<(usize, Item)> {
-        let mut targets = Vec::new();
-        for (ti, track) in self.children.iter().enumerate() {
-            for (ii, item) in track.items.iter().enumerate() {
-                if let Item::Clip(clip) = item {
-                    if resolve_sync_clips_id(&clip.metadata) == Some(sync_clips_id) {
-                        targets.push((ti, ii));
-                    }
-                }
-            }
-        }
-
-        targets.sort_by(|a, b| b.cmp(a));
-        let mut removed = Vec::new();
-        let mut used_ids = self.collect_timeline_ids();
-        for (ti, ii) in targets {
-            if ti >= self.children.len() || ii >= self.children[ti].items.len() {
-                continue;
-            }
-            let removed_item = self.children[ti].items.remove(ii);
-            let duration = removed_item.duration().max(0.0);
-            if replace_with_gap && duration > EPS {
-                let mut gap = Item::Gap(crate::Gap::make_gap(duration));
-                Self::ensure_unique_item_id(&mut gap, &mut used_ids);
-                self.children[ti].items.insert(ii, gap);
-                self.children[ti].merge_adjacent_gaps();
-            }
-            removed.push((ti, removed_item));
-        }
-        removed.reverse();
-        removed
+        self.delete_clips_at_indices(self.synced_clips_targets(sync_clips_id), replace_with_gap)
     }
 
     fn clip_target(&self, item_id: &str) -> Option<(usize, usize)> {

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -713,7 +713,8 @@ impl Stack {
                     continue;
                 }
                 if let Some(ii) = self.item_at_column(ti, column_start, column_duration) {
-                    if matches!(self.children[ti].items[ii], Item::Gap(_)) {
+                    let column_item = &self.children[ti].items[ii];
+                    if matches!(column_item, Item::Gap(_)) || Self::item_is_unsynced(column_item) {
                         clips_to_delete.push((ti, ii));
                         covered_tracks.insert(ti);
                         continue;

--- a/tellers-timeline-core/src/stack_methods/stack_item_delete.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_item_delete.rs
@@ -1,32 +1,47 @@
 use crate::{Item, Stack};
 
 impl Stack {
-    /// Delete an item by id across all tracks. Synced clips with the same Resolve
-    /// link group are deleted too. If replace_with_gap is true and a removed item
-    /// has a positive duration, a gap of equal duration is inserted.
+    /// Delete an item by id. Synced clips in the same link group at the same column
+    /// are deleted together. When `replace_with_gap` is true, the column is replaced
+    /// with gaps on every affected sync track. When false, the column is collapsed
+    /// across the sync track cluster (padding gaps are inserted on bound tracks when
+    /// needed, then removed with the deleted items).
     /// Returns removed items with their source track indices.
     pub fn delete_item(&mut self, item_id: &str, replace_with_gap: bool) -> Vec<(usize, Item)> {
-        let sync_clips_id = match self.get_item(item_id).and_then(|(_, _, item)| match item {
-            Item::Clip(clip) => super::resolve_sync_clips_id(&clip.metadata),
-            Item::Gap(_) => None,
-        }) {
-            Some(id) => id,
-            None => {
-                let removed: Vec<_> = self
-                    .delete_one_item(item_id, replace_with_gap)
-                    .into_iter()
-                    .collect();
-                if !removed.is_empty() {
-                    self.sanitize();
-                }
-                return removed;
-            }
+        let Some((track_index, item_index, item)) = self.get_item(item_id) else {
+            return Vec::new();
         };
 
-        let removed = self.delete_sync_clips(sync_clips_id, replace_with_gap);
-        if !removed.is_empty() {
-            self.sanitize();
+        if matches!(item, Item::Gap(_)) && replace_with_gap {
+            return Vec::new();
         }
-        removed
+
+        let column_start = self.children[track_index].start_time_of_item(item_index);
+        let column_duration = item.duration().max(0.0);
+        let cluster = self.boundary_group_indices(track_index);
+        let sync_clips_id = match &item {
+            Item::Clip(clip) => super::resolve_sync_clips_id(&clip.metadata),
+            Item::Gap(_) => None,
+        };
+
+        if replace_with_gap {
+            self.delete_item_replace_with_gap(
+                item_id,
+                track_index,
+                item_index,
+                &cluster,
+                column_start,
+                column_duration,
+                sync_clips_id,
+            )
+        } else {
+            self.delete_item_collapse(
+                item_id,
+                &cluster,
+                column_start,
+                column_duration,
+                sync_clips_id,
+            )
+        }
     }
 }

--- a/tellers-timeline-core/src/stack_methods/stack_item_delete.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_item_delete.rs
@@ -1,20 +1,19 @@
 use crate::{Item, Stack};
 
 impl Stack {
-    /// Delete an item by id. Synced clips in the same link group at the same column
-    /// are deleted together. When `replace_with_gap` is true, the column is replaced
-    /// with gaps on every affected sync track. When false, the column is collapsed
-    /// across the sync track cluster (padding gaps are inserted on bound tracks when
-    /// needed, then removed with the deleted items).
+    /// Delete an item by id. Synced clips in the same link group are deleted
+    /// together. When `replace_with_gap` is true, each removed clip is replaced
+    /// with a gap of the same duration. When false, the column is collapsed
+    /// across the sync track cluster.
     /// Returns removed items with their source track indices.
     pub fn delete_item(&mut self, item_id: &str, replace_with_gap: bool) -> Vec<(usize, Item)> {
+        if replace_with_gap {
+            return self.delete_item_replace_with_gap(item_id);
+        }
+
         let Some((track_index, item_index, item)) = self.get_item(item_id) else {
             return Vec::new();
         };
-
-        if matches!(item, Item::Gap(_)) && replace_with_gap {
-            return Vec::new();
-        }
 
         let column_start = self.children[track_index].start_time_of_item(item_index);
         let column_duration = item.duration().max(0.0);
@@ -24,24 +23,12 @@ impl Stack {
             Item::Gap(_) => None,
         };
 
-        if replace_with_gap {
-            self.delete_item_replace_with_gap(
-                item_id,
-                track_index,
-                item_index,
-                &cluster,
-                column_start,
-                column_duration,
-                sync_clips_id,
-            )
-        } else {
-            self.delete_item_collapse(
-                item_id,
-                &cluster,
-                column_start,
-                column_duration,
-                sync_clips_id,
-            )
-        }
+        self.delete_item_collapse(
+            item_id,
+            &cluster,
+            column_start,
+            column_duration,
+            sync_clips_id,
+        )
     }
 }

--- a/tellers-timeline-core/src/stack_methods/stack_item_delete.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_item_delete.rs
@@ -8,27 +8,9 @@ impl Stack {
     /// Returns removed items with their source track indices.
     pub fn delete_item(&mut self, item_id: &str, replace_with_gap: bool) -> Vec<(usize, Item)> {
         if replace_with_gap {
-            return self.delete_item_replace_with_gap(item_id);
+            self.delete_item_replace_with_gap(item_id)
+        } else {
+            self.delete_item_collapse(item_id)
         }
-
-        let Some((track_index, item_index, item)) = self.get_item(item_id) else {
-            return Vec::new();
-        };
-
-        let column_start = self.children[track_index].start_time_of_item(item_index);
-        let column_duration = item.duration().max(0.0);
-        let cluster = self.boundary_group_indices(track_index);
-        let sync_clips_id = match &item {
-            Item::Clip(clip) => super::resolve_sync_clips_id(&clip.metadata),
-            Item::Gap(_) => None,
-        };
-
-        self.delete_item_collapse(
-            item_id,
-            &cluster,
-            column_start,
-            column_duration,
-            sync_clips_id,
-        )
     }
 }

--- a/tellers-timeline-core/src/stack_methods/stack_item_replace.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_item_replace.rs
@@ -1,5 +1,5 @@
-use super::{range_is_gap_backed, resolve_sync_clips_id, split_gap_boundary, EPS};
-use crate::{Gap, IdMetadataExt, InsertPolicy, Item, OverlapPolicy, Seconds, Stack, Track, TrackKind};
+use super::{resolve_sync_clips_id, EPS};
+use crate::{Gap, IdMetadataExt, InsertPolicy, Item, OverlapPolicy, Stack, TrackKind};
 
 fn shift_track_index_after_insert(track_index: &mut usize, inserted_track_index: usize) {
     if inserted_track_index <= *track_index {
@@ -20,34 +20,6 @@ fn shift_insert_tracks_after_insert(insertions: &mut [(usize, Item)], inserted_t
     for (track_index, _) in insertions {
         shift_track_index_after_insert(track_index, inserted_track_index);
     }
-}
-
-fn remove_gap_range(track: &mut Track, start: Seconds, end: Seconds) -> bool {
-    if !range_is_gap_backed(track, start, end) {
-        return false;
-    }
-
-    split_gap_boundary(track, end);
-    split_gap_boundary(track, start);
-
-    let mut pos = 0.0;
-    let mut index = 0;
-    while index < track.items.len() {
-        let duration = track.items[index].duration().max(0.0);
-        let item_start = pos;
-        let item_end = pos + duration;
-        if item_start >= start - EPS && item_end <= end + EPS {
-            if !matches!(track.items[index], Item::Gap(_)) {
-                return false;
-            }
-            track.items.remove(index);
-            pos = item_end;
-        } else {
-            pos = item_end;
-            index += 1;
-        }
-    }
-    true
 }
 
 impl Stack {
@@ -187,7 +159,7 @@ impl Stack {
                             *self = backup;
                             return false;
                         };
-                        if !remove_gap_range(track, (end - shrink).max(selected_start), end) {
+                        if !super::remove_gap_range(track, (end - shrink).max(selected_start), end) {
                             *self = backup;
                             return false;
                         }

--- a/tellers-timeline-core/src/track_methods/track_item_delete.rs
+++ b/tellers-timeline-core/src/track_methods/track_item_delete.rs
@@ -1,10 +1,9 @@
 use crate::{Item, Track};
 
 impl Track {
-    /// Delete the clip at a given index. If `replace_with_gap` is true, insert a gap of the
-    /// same duration at that position and merge adjacent gaps.
-    /// Returns whether a deletion occurred.
-    pub(crate) fn delete_clip(&mut self, index: usize, replace_with_gap: bool) -> bool {
+    /// Remove the clip or gap at `index`, optionally inserting a gap of the same
+    /// duration. Does not run track sanitize; callers batch sanitize at the stack level.
+    pub(crate) fn delete_clip_at(&mut self, index: usize, replace_with_gap: bool) -> bool {
         if index >= self.items.len() {
             return false;
         }
@@ -17,16 +16,27 @@ impl Track {
                         index.min(self.items.len()),
                         Item::Gap(crate::types::Gap::make_gap(removed_duration)),
                     );
+                    self.merge_adjacent_gaps();
                 }
-                self.sanitize();
                 true
             }
             Item::Gap(_) if !replace_with_gap => {
                 self.items.remove(index);
-                self.sanitize();
                 true
             }
             Item::Gap(_) => false,
+        }
+    }
+
+    /// Delete the clip at a given index. If `replace_with_gap` is true, insert a gap of the
+    /// same duration at that position and merge adjacent gaps.
+    /// Returns whether a deletion occurred.
+    pub(crate) fn delete_clip(&mut self, index: usize, replace_with_gap: bool) -> bool {
+        if self.delete_clip_at(index, replace_with_gap) {
+            self.sanitize();
+            true
+        } else {
+            false
         }
     }
 }

--- a/tellers-timeline-core/tests/delete.rs
+++ b/tellers-timeline-core/tests/delete.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use tellers_timeline_core::{
-    Clip, IdMetadataExt, Item, MediaReference, RationalTime, Stack, TimeRange, Track,
+    Clip, IdMetadataExt, Item, MediaReference, RationalTime, Stack, TimeRange, Timeline, Track,
 };
 
 fn make_clip(name: &str, duration: f64, media_start: f64) -> Item {
@@ -148,4 +148,63 @@ fn delete_item_sanitizes_stack_after_successful_delete() {
     assert_eq!(deleted.len(), 1);
     assert_eq!(stack.children[0].items.len(), 1);
     assert!(matches!(stack.children[0].items[0], Item::Clip(_)));
+}
+
+fn fixture_path(name: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+fn track_index_by_id(stack: &Stack, id: &str) -> usize {
+    stack
+        .children
+        .iter()
+        .position(|track| track.get_id().as_deref() == Some(id))
+        .unwrap_or_else(|| panic!("track {id:?} not found"))
+}
+
+fn assert_item_span(track: &Track, item_index: usize, expected_start: f64, expected_duration: f64) {
+    let start = track.start_time_of_item(item_index);
+    let duration = track.items[item_index].duration();
+    assert!(
+        (start - expected_start).abs() < 1e-9,
+        "item {item_index} start: got {start}, expected {expected_start}"
+    );
+    assert!(
+        (duration - expected_duration).abs() < 1e-9,
+        "item {item_index} duration: got {duration}, expected {expected_duration}"
+    );
+}
+
+#[test]
+fn delete_new_project_clip_454bfdad4796_without_gap_collapses_sync_cluster() {
+    let json = std::fs::read_to_string(fixture_path("new_project_delete.otio")).expect("fixture");
+    let mut tl: Timeline = serde_json::from_str(&json).expect("parse");
+    tl.sanitize();
+
+    let removed = tl.tracks.delete_item("454bfdad4796", false);
+    assert_eq!(removed.len(), 2);
+    assert!(tl.tracks.get_item("454bfdad4796").is_none());
+    assert!(tl.tracks.get_item("4f85c014f851").is_some());
+    assert!(tl.tracks.get_item("6f5b5c689849").is_some());
+
+    let video = track_index_by_id(&tl.tracks, "536db79b4178");
+    let audio = track_index_by_id(&tl.tracks, "A3");
+    let other_video = track_index_by_id(&tl.tracks, "20c3a044a84b");
+
+    let video_track = &tl.tracks.children[video];
+    assert_eq!(video_track.items.len(), 1);
+    assert_item_span(video_track, 0, 0.0, 47.0);
+    assert_eq!(video_track.items[0].get_id().as_deref(), Some("4f85c014f851"));
+
+    let audio_track = &tl.tracks.children[audio];
+    assert_eq!(audio_track.items.len(), 1);
+    assert_item_span(audio_track, 0, 0.0, 47.0);
+    assert_eq!(audio_track.items[0].get_id().as_deref(), Some("6f5b5c689849"));
+
+    let other_video_track = &tl.tracks.children[other_video];
+    assert_eq!(other_video_track.items.len(), 2);
+    assert_item_span(other_video_track, 0, 0.0, 5.0);
+    assert_item_span(other_video_track, 1, 5.0, 43.96);
 }

--- a/tellers-timeline-core/tests/fixtures/new_project_delete.otio
+++ b/tellers-timeline-core/tests/fixtures/new_project_delete.otio
@@ -1,0 +1,484 @@
+{
+    "OTIO_SCHEMA": "Timeline.1",
+    "metadata": {
+        "Resolve_OTIO": {
+            "Resolve OTIO Meta Version": "1.0"
+        },
+        "tellers.ai": {
+            "timeline_id": "8ce7cadc0796"
+        },
+        "tellers_aspect_ratio": "16_9"
+    },
+    "name": "",
+    "global_start_time": null,
+    "tracks": {
+        "OTIO_SCHEMA": "Stack.1",
+        "metadata": {
+            "tellers.ai": {
+                "timeline_id": "3c71a7c6f28b"
+            }
+        },
+        "name": "",
+        "source_range": null,
+        "effects": [],
+        "markers": [],
+        "enabled": true,
+        "color": null,
+        "children": [
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "tellers.ai": {
+                        "media_id": null,
+                        "timeline_id": "A2"
+                    }
+                },
+                "name": "A2",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "color": null,
+                "children": [],
+                "kind": "audio"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "tellers.ai": {
+                        "media_id": null,
+                        "timeline_id": "d98bc55301d5"
+                    }
+                },
+                "name": "Overlay",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "color": null,
+                "children": [],
+                "kind": "video"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "tellers.ai": {
+                        "media_id": null,
+                        "timeline_id": "A1"
+                    }
+                },
+                "name": "A1",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "color": null,
+                "children": [],
+                "kind": "audio"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "tellers.ai": {
+                        "media_id": null,
+                        "timeline_id": "20c3a044a84b"
+                    }
+                },
+                "name": "Overlay Top",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "color": null,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "active_media_reference_key": null,
+                        "media_references": {},
+                        "metadata": {
+                            "Resolve_OTIO": null,
+                            "tellers.ai": {
+                                "media_id": null,
+                                "timeline_id": "e8ea973e6084"
+                            }
+                        },
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 1.0,
+                                "value": 5.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 1.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "color": null
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": null,
+                            "tellers.ai": {
+                                "media_id": null,
+                                "timeline_id": "82e96f415570"
+                            }
+                        },
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 25.0,
+                                "value": 1099.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 25.0,
+                                "value": 76.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Transform",
+                                        "Enabled": true,
+                                        "Name": "Transform",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Parameter ID": "transformationPan",
+                                                "Parameter Value": 0.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 4.0,
+                                                "minValue": -4.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Parameter ID": "transformationTilt",
+                                                "Parameter Value": 0.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 4.0,
+                                                "minValue": -4.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Parameter ID": "transformationZoomX",
+                                                "Parameter Value": 1.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Parameter ID": "transformationZoomY",
+                                                "Parameter Value": 1.1851851851851851,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Parameter ID": "transformationRotationAngle",
+                                                "Parameter Value": 0.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100000.0,
+                                                "minValue": -100000.0
+                                            }
+                                        ],
+                                        "Type": 2
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect",
+                                "enabled": true
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": true,
+                        "color": null,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": null,
+                                    "tellers.ai": {
+                                        "media_id": "b9243eda-e571-4c85-8b40-77a28b9473d7",
+                                        "timeline_id": null
+                                    }
+                                },
+                                "name": "DEFAULT_MEDIA",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 25.0,
+                                        "value": 10368000.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 25.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "_DSC9756 R.jpg"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    }
+                ],
+                "kind": "video"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "tellers.ai": {
+                        "media_id": null,
+                        "timeline_id": "A3"
+                    }
+                },
+                "name": "A3",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "color": null,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "active_media_reference_key": null,
+                        "media_references": {},
+                        "metadata": {
+                            "Resolve_OTIO": null,
+                            "tellers.ai": {
+                                "media_id": null,
+                                "timeline_id": "c73bbb34fcaf"
+                            }
+                        },
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 1.0,
+                                "value": 5.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 1.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "color": null
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Link Group ID": 2
+                            },
+                            "tellers.ai": {
+                                "media_id": null,
+                                "timeline_id": "6f5b5c689849"
+                            }
+                        },
+                        "name": "MACIF_PGEE_50sec.mp4 audio",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 25.0,
+                                "value": 1175.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 25.0,
+                                "value": 72.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "color": null,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": null,
+                                    "tellers.ai": {
+                                        "media_id": "bf590efe-29ee-47c7-9cd6-75e56187228b",
+                                        "timeline_id": ""
+                                    }
+                                },
+                                "name": "",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 25.0,
+                                        "value": 1247.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 25.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "MACIF_PGEE_50sec.mp4"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    }
+                ],
+                "kind": "audio"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "tellers.ai": {
+                        "media_id": null,
+                        "timeline_id": "536db79b4178"
+                    }
+                },
+                "name": "Main Video",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "color": null,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": null,
+                            "tellers.ai": {
+                                "media_id": null,
+                                "timeline_id": "454bfdad4796"
+                            }
+                        },
+                        "name": "_DSC9756 R.jpg",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 25.0,
+                                "value": 125.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 25.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "color": null,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": null,
+                                    "tellers.ai": {
+                                        "media_id": "b9243eda-e571-4c85-8b40-77a28b9473d7",
+                                        "timeline_id": ""
+                                    }
+                                },
+                                "name": "",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 25.0,
+                                        "value": 10368000.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 25.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "_DSC9756 R.jpg"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Link Group ID": 2
+                            },
+                            "tellers.ai": {
+                                "media_id": null,
+                                "timeline_id": "4f85c014f851"
+                            }
+                        },
+                        "name": "MACIF_PGEE_50sec.mp4",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 25.0,
+                                "value": 1175.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 25.0,
+                                "value": 72.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "color": null,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": null,
+                                    "tellers.ai": {
+                                        "media_id": "bf590efe-29ee-47c7-9cd6-75e56187228b",
+                                        "timeline_id": ""
+                                    }
+                                },
+                                "name": "",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 25.0,
+                                        "value": 1247.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 25.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "MACIF_PGEE_50sec.mp4"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    }
+                ],
+                "kind": "video"
+            }
+        ]
+    }
+}

--- a/tellers-timeline-core/tests/synced.rs
+++ b/tellers-timeline-core/tests/synced.rs
@@ -3064,7 +3064,7 @@ fn delete_clip_a_collapse_pulls_synced_partner_left() {
     let a1 = track_index_by_id(&stack, "a1");
 
     let removed = stack.delete_item("clip-a", false);
-    assert_eq!(removed.len(), 1);
+    assert_eq!(removed.len(), 2);
     assert!(stack.get_item("clip-a").is_none());
     assert!(stack.get_item("clip-b-video").is_some());
     assert!(stack.get_item("clip-b-audio").is_some());
@@ -3123,7 +3123,7 @@ fn delete_unsynced_item_without_gap_pulls_later_synced_assets() {
 
     let removed = stack.delete_item("unlinked", false);
 
-    assert_eq!(removed.len(), 1);
+    assert_eq!(removed.len(), 2);
     let (video_track_index, video_item_index, _) = stack.get_item("linked-video").unwrap();
     let (audio_track_index, audio_item_index, _) = stack.get_item(&audio_id).unwrap();
     assert_eq!(

--- a/tellers-timeline-core/tests/synced.rs
+++ b/tellers-timeline-core/tests/synced.rs
@@ -2994,6 +2994,94 @@ fn synced_delete_without_gap_collapses_sync_clips() {
     assert!(stack.children.iter().all(|track| track.items.is_empty()));
 }
 
+fn stack_v1_clip_a_clip_b_a1() -> Stack {
+    let mut video = Track::new(TrackKind::Video, Some("v1".to_string()));
+    video.items.push(Item::Clip(clip(10.0, Some("clip-a"))));
+    video.items.push(synced_clip_item(10.0, "clip-b-video", 1));
+    let mut audio = Track::new(TrackKind::Audio, Some("a1".to_string()));
+    audio.items.push(Item::Gap(Gap::make_gap(10.0)));
+    audio.items.push(synced_clip_item(10.0, "clip-b-audio", 1));
+    let mut stack = Stack::default();
+    stack.children.push(video);
+    stack.children.push(audio);
+    stack
+}
+
+fn track_index_by_id(stack: &Stack, id: &str) -> usize {
+    stack
+        .children
+        .iter()
+        .position(|track| track.get_id().as_deref() == Some(id))
+        .unwrap_or_else(|| panic!("track {id:?} not found"))
+}
+
+fn assert_item_span(track: &Track, item_index: usize, expected_start: f64, expected_duration: f64) {
+    let start = track.start_time_of_item(item_index);
+    let duration = track.items[item_index].duration();
+    assert!(
+        (start - expected_start).abs() < 1e-9,
+        "item {item_index} start: got {start}, expected {expected_start}"
+    );
+    assert!(
+        (duration - expected_duration).abs() < 1e-9,
+        "item {item_index} duration: got {duration}, expected {expected_duration}"
+    );
+}
+
+#[test]
+fn delete_clip_a_replace_with_gap_preserves_synced_partner_spans() {
+    let mut stack = stack_v1_clip_a_clip_b_a1();
+    let v1 = track_index_by_id(&stack, "v1");
+    let a1 = track_index_by_id(&stack, "a1");
+
+    let removed = stack.delete_item("clip-a", true);
+    assert_eq!(removed.len(), 1);
+    assert!(stack.get_item("clip-a").is_none());
+    assert!(stack.get_item("clip-b-video").is_some());
+    assert!(stack.get_item("clip-b-audio").is_some());
+
+    let video = &stack.children[v1];
+    assert_eq!(video.items.len(), 2);
+    assert!(matches!(video.items[0], Item::Gap(_)));
+    assert_item_span(video, 0, 0.0, 10.0);
+    assert_item_span(video, 1, 10.0, 10.0);
+
+    let audio = &stack.children[a1];
+    assert_eq!(audio.items.len(), 2);
+    assert!(matches!(audio.items[0], Item::Gap(_)));
+    assert_item_span(audio, 0, 0.0, 10.0);
+    assert_item_span(audio, 1, 10.0, 10.0);
+    assert_eq!(
+        sync_clips_id(&video.items[1]),
+        sync_clips_id(&audio.items[1])
+    );
+}
+
+#[test]
+fn delete_clip_a_collapse_pulls_synced_partner_left() {
+    let mut stack = stack_v1_clip_a_clip_b_a1();
+    let v1 = track_index_by_id(&stack, "v1");
+    let a1 = track_index_by_id(&stack, "a1");
+
+    let removed = stack.delete_item("clip-a", false);
+    assert_eq!(removed.len(), 1);
+    assert!(stack.get_item("clip-a").is_none());
+    assert!(stack.get_item("clip-b-video").is_some());
+    assert!(stack.get_item("clip-b-audio").is_some());
+
+    let video = &stack.children[v1];
+    assert_eq!(video.items.len(), 1);
+    assert_item_span(video, 0, 0.0, 10.0);
+
+    let audio = &stack.children[a1];
+    assert_eq!(audio.items.len(), 1);
+    assert_item_span(audio, 0, 0.0, 10.0);
+    assert_eq!(
+        sync_clips_id(&video.items[0]),
+        sync_clips_id(&audio.items[0])
+    );
+}
+
 #[test]
 fn delete_unsynced_item_only_removes_selected_item() {
     let mut video = Track::new(TrackKind::Video, Some("v".to_string()));

--- a/tellers-timeline-core/tests/synced.rs
+++ b/tellers-timeline-core/tests/synced.rs
@@ -2971,6 +2971,30 @@ fn synced_delete_keeps_touched_tracks_without_remaining_clips() {
 }
 
 #[test]
+fn synced_delete_without_gap_collapses_sync_clips() {
+    let mut stack = Stack::default();
+    stack
+        .children
+        .push(Track::new(TrackKind::Video, Some("v".to_string())));
+    stack
+        .children
+        .push(Track::new(TrackKind::Audio, Some("a".to_string())));
+
+    insert_with_audio(
+        &mut stack,
+        0,
+        0.0,
+        clip(3.0, Some("primary")),
+        vec![audio_clip(3.0, "file:///a1.wav", None)],
+    )
+    .unwrap();
+
+    let removed = stack.delete_item("primary", false);
+    assert_eq!(removed.len(), 2);
+    assert!(stack.children.iter().all(|track| track.items.is_empty()));
+}
+
+#[test]
 fn delete_unsynced_item_only_removes_selected_item() {
     let mut video = Track::new(TrackKind::Video, Some("v".to_string()));
     video.items.push(Item::Clip(clip(3.0, Some("primary"))));


### PR DESCRIPTION
## Summary
- Reworks `delete_item` to operate on the sync track cluster (`boundary_group_indices`) instead of only synced clip link groups.
- **`replace_with_gap = true`**: finds the item and its sync tracks, replaces the column with gaps on every affected track, then sanitizes.
- **`replace_with_gap = false`**: collapses the column across the cluster — bound tracks without a synced item at the column get a temporary gap, then the item, synced partners, and padding gaps are removed together.
- Extracts `remove_gap_range` to shared stack helpers (also used by `replace_item`).

## Test plan
- [x] `cargo test -p tellers-timeline-core`
- [x] Added `synced_delete_without_gap_collapses_sync_clips` test


Made with [Cursor](https://cursor.com)