### PR TITLE
Fix intra-cluster synced moves placing video on wrong track

### DIFF
--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -244,11 +244,53 @@ impl Stack {
         true
     }
 
+    fn sync_split_id_policy_for_inserted_item(item: &Item) -> SyncSplitIdPolicy {
+        match item {
+            Item::Clip(clip) if resolve_sync_clips_id(&clip.metadata).is_some() => {
+                SyncSplitIdPolicy::KeepShared
+            }
+            _ => SyncSplitIdPolicy::AssignNewIdToRight,
+        }
+    }
+
+    fn apply_sync_splits_for_column_insert(
+        &mut self,
+        start: Seconds,
+        duration: Seconds,
+        insert_policy: InsertPolicy,
+        overlap_policy: OverlapPolicy,
+        id_policy: SyncSplitIdPolicy,
+    ) -> bool {
+        let mut split_times = Vec::new();
+        if matches!(insert_policy, InsertPolicy::SplitAndInsert) {
+            split_times.push(start);
+        }
+        if overlap_policy == OverlapPolicy::Override && duration > EPS {
+            if !split_times
+                .iter()
+                .any(|time| (*time - start).abs() <= EPS)
+            {
+                split_times.push(start);
+            }
+            if matches!(id_policy, SyncSplitIdPolicy::KeepShared) {
+                split_times.push(start + duration);
+            }
+        }
+        split_times.sort_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
+        split_times.dedup_by(|left, right| (*left - *right).abs() <= EPS);
+        for split_time in split_times {
+            if !self.split_sync_clips_at_time(split_time, id_policy) {
+                return false;
+            }
+        }
+        true
+    }
+
     fn prepare_sync_splits_for_insert(
         &mut self,
         track_index: usize,
         insert_time: Seconds,
-        item_duration: Seconds,
+        item: &Item,
         insert_policy: InsertPolicy,
         overlap_policy: OverlapPolicy,
     ) {
@@ -259,16 +301,14 @@ impl Stack {
         ) else {
             return;
         };
-        if matches!(insert_policy, InsertPolicy::SplitAndInsert) {
-            let _ = self.split_sync_clips_at_time(start, SyncSplitIdPolicy::KeepShared);
-        }
-        if overlap_policy == OverlapPolicy::Override && item_duration > EPS {
-            let _ = self.split_sync_clips_at_time(start, SyncSplitIdPolicy::KeepShared);
-            let _ = self.split_sync_clips_at_time(
-                start + item_duration,
-                SyncSplitIdPolicy::KeepShared,
-            );
-        }
+        let id_policy = Self::sync_split_id_policy_for_inserted_item(item);
+        let _ = self.apply_sync_splits_for_column_insert(
+            start,
+            item.duration().max(0.0),
+            insert_policy,
+            overlap_policy,
+            id_policy,
+        );
     }
 
     fn insert_at_time_with_sync_splits(
@@ -282,7 +322,7 @@ impl Stack {
         self.prepare_sync_splits_for_insert(
             track_index,
             insert_time,
-            item.duration().max(0.0),
+            &item,
             insert_policy,
             overlap_policy,
         );
@@ -1634,6 +1674,20 @@ impl Stack {
         }
         column.sort_by_key(|(track_index, _)| *track_index);
 
+        if overlap_policy == OverlapPolicy::Override
+            && matches!(insert_policy, InsertPolicy::SplitAndInsert)
+            && !self.apply_sync_splits_for_column_insert(
+                start,
+                modified_duration,
+                insert_policy,
+                overlap_policy,
+                SyncSplitIdPolicy::AssignNewIdToRight,
+            )
+        {
+            *self = backup;
+            return None;
+        }
+
         // Insert the whole column. The primary lands at the requested position
         // with the caller's insert policy; every other track receives its item
         // at the same resolved start with the same overlap policy, splitting at
@@ -2829,26 +2883,15 @@ impl Stack {
             SyncedMovePlacement::Time { insert_policy, .. } => insert_policy,
             SyncedMovePlacement::Index { .. } => InsertPolicy::SplitAndInsert,
         };
-        let mut split_times = Vec::new();
-        if matches!(insert_policy, InsertPolicy::SplitAndInsert) {
-            split_times.push(moved_start);
-        }
-        if overlap_policy == OverlapPolicy::Override && moved_duration > EPS {
-            if !split_times
-                .iter()
-                .any(|time| (*time - moved_start).abs() <= EPS)
-            {
-                split_times.push(moved_start);
-            }
-            split_times.push(moved_start + moved_duration);
-        }
-        split_times.sort_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
-        split_times.dedup_by(|left, right| (*left - *right).abs() <= EPS);
-        for split_time in split_times {
-            if !self.split_sync_clips_at_time(split_time, SyncSplitIdPolicy::KeepShared) {
-                *self = backup;
-                return false;
-            }
+        if !self.apply_sync_splits_for_column_insert(
+            moved_start,
+            moved_duration,
+            insert_policy,
+            overlap_policy,
+            SyncSplitIdPolicy::KeepShared,
+        ) {
+            *self = backup;
+            return false;
         }
 
         for (track_index, item, is_selected) in placements {

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -864,6 +864,31 @@ impl Stack {
         targets
     }
 
+    fn sync_column_targets_at(
+        &self,
+        sync_clips_id: i64,
+        column_start: Seconds,
+        column_duration: Seconds,
+    ) -> Vec<(usize, usize)> {
+        self.synced_clips_targets(sync_clips_id)
+            .into_iter()
+            .filter(|(track_index, item_index)| {
+                self.item_occupies_column(*track_index, *item_index, column_start, column_duration)
+            })
+            .collect()
+    }
+
+    fn is_independent_sync_column(
+        &self,
+        sync_clips_id: i64,
+        column_start: Seconds,
+        column_duration: Seconds,
+    ) -> bool {
+        self.sync_column_targets_at(sync_clips_id, column_start, column_duration)
+            .len()
+            > 1
+    }
+
     fn item_is_unsynced(item: &Item) -> bool {
         match item {
             Item::Clip(clip) => resolve_sync_clips_id(&clip.metadata).is_none(),
@@ -2289,7 +2314,13 @@ impl Stack {
             Item::Clip(clip) => resolve_sync_clips_id(&clip.metadata),
             Item::Gap(_) => None,
         }?;
-        let targets = self.synced_clips_targets(sync_clips_id);
+        let selected_start = self.children[selected_track_index]
+            .start_time_of_item(selected_item_index);
+        let selected_duration = selected_item.duration().max(0.0);
+        if selected_duration <= EPS {
+            return None;
+        }
+        let targets = self.sync_column_targets_at(sync_clips_id, selected_start, selected_duration);
         if targets.len() <= 1 {
             return None;
         }
@@ -2312,20 +2343,6 @@ impl Stack {
                 item,
                 is_selected,
             });
-        }
-
-        let selected_start = self.children[selected_track_index]
-            .start_time_of_item(selected_item_index);
-        let selected_duration = selected_item.duration().max(0.0);
-        if selected_duration <= EPS
-            || !items.iter().all(|move_item| {
-                let start = self.children[move_item.track_index]
-                    .start_time_of_item(move_item.item_index);
-                (start - selected_start).abs() <= EPS
-                    && (move_item.item.duration().max(0.0) - selected_duration).abs() <= EPS
-            })
-        {
-            return None;
         }
 
         Some(items)
@@ -2352,6 +2369,18 @@ impl Stack {
     }
 
     fn linked_item_ids_for_move(&self, item_timeline_id: &str, item_to_move: &Item) -> Vec<String> {
+        let Some((primary_track_index, primary_item_index, _)) = self.get_item(item_timeline_id)
+        else {
+            return Vec::new();
+        };
+        let primary_start = self.children[primary_track_index]
+            .start_time_of_item(primary_item_index);
+        let primary_duration = item_to_move.duration().max(0.0);
+        let primary_sync_id = match item_to_move {
+            Item::Clip(clip) => resolve_sync_clips_id(&clip.metadata),
+            Item::Gap(_) => None,
+        };
+
         let mut selected_ids = HashSet::from([item_timeline_id.to_string()]);
         let mut selected_link_group_ids = HashSet::<i64>::new();
         let mut selected_tellers_group_ids = HashSet::<i64>::new();
@@ -2367,9 +2396,11 @@ impl Stack {
 
         loop {
             let mut changed = false;
-            for track in &self.children {
-                for item in &track.items {
+            for (track_index, track) in self.children.iter().enumerate() {
+                let mut pos = 0.0;
+                for (item_index, item) in track.items.iter().enumerate() {
                     if !matches!(item, Item::Clip(_)) {
+                        pos += item.duration().max(0.0);
                         continue;
                     }
                     let linked = item_link_group_id(item)
@@ -2377,9 +2408,35 @@ impl Stack {
                     let grouped = item_tellers_group_id(item)
                         .is_some_and(|id| selected_tellers_group_ids.contains(&id));
                     if !linked && !grouped {
+                        pos += item.duration().max(0.0);
                         continue;
                     }
+                    if let Some(sync_id) = primary_sync_id {
+                        if resolve_sync_clips_id(match item {
+                            Item::Clip(clip) => &clip.metadata,
+                            Item::Gap(_) => {
+                                pos += item.duration().max(0.0);
+                                continue;
+                            }
+                        }) == Some(sync_id)
+                            && !self.item_occupies_column(
+                                track_index,
+                                item_index,
+                                primary_start,
+                                primary_duration,
+                            )
+                            && self.is_independent_sync_column(
+                                sync_id,
+                                pos,
+                                item.duration().max(0.0),
+                            )
+                        {
+                            pos += item.duration().max(0.0);
+                            continue;
+                        }
+                    }
                     let Some(item_id) = item.get_id() else {
+                        pos += item.duration().max(0.0);
                         continue;
                     };
                     if selected_ids.insert(item_id) {
@@ -2391,6 +2448,7 @@ impl Stack {
                     if let Some(tellers_group_id) = item_tellers_group_id(item) {
                         changed |= selected_tellers_group_ids.insert(tellers_group_id);
                     }
+                    pos += item.duration().max(0.0);
                 }
             }
             if !changed {

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -505,6 +505,36 @@ impl Stack {
         }
     }
 
+    fn try_reuse_video_track_for_audio_move(
+        &self,
+        track_index: usize,
+        audio_track_index: usize,
+        dest_time: Seconds,
+        end_time: Seconds,
+        sync_clips_id: Option<i64>,
+        use_sync_backed_track: bool,
+        overlap_policy: OverlapPolicy,
+    ) -> Option<usize> {
+        if self.children.get(track_index)?.kind != TrackKind::Video {
+            return None;
+        }
+        if range_is_gap_backed(&self.children[track_index], dest_time, end_time) {
+            return Some(track_index);
+        }
+        let has_blocking_clip = range_has_blocking_clip(
+            &self.children[track_index],
+            dest_time,
+            end_time,
+            sync_clips_id,
+        );
+        let can_push_existing_boundary = overlap_policy == OverlapPolicy::Push
+            && self.track_matches_primary_sync_boundary(audio_track_index, track_index);
+        if !has_blocking_clip || can_push_existing_boundary {
+            return use_sync_backed_track.then_some(track_index);
+        }
+        None
+    }
+
     fn find_or_create_video_track_for_audio(
         &mut self,
         audio_track_index: usize,
@@ -516,41 +546,54 @@ impl Stack {
         overlap_policy: OverlapPolicy,
     ) -> Option<usize> {
         let end_time = dest_time + duration;
-        let mut group_start = audio_track_index;
-        while group_start > 0 && self.children[group_start - 1].kind == TrackKind::Audio {
-            group_start -= 1;
-            if track_is_empty_boundary(&self.children[group_start]) {
+        let mut audio_start = audio_track_index;
+        while audio_start > 0 && self.children[audio_start - 1].kind == TrackKind::Audio {
+            audio_start -= 1;
+            if track_is_empty_boundary(&self.children[audio_start]) {
                 break;
             }
         }
-        if group_start > 0
-            && !track_is_empty_boundary(&self.children[group_start])
-            && self.children[group_start - 1].kind == TrackKind::Video
-        {
-            group_start -= 1;
+        let mut audio_end = audio_track_index + 1;
+        while audio_end < self.children.len() && self.children[audio_end].kind == TrackKind::Audio {
+            audio_end += 1;
         }
 
-        if self.children.get(group_start)?.kind == TrackKind::Video {
-            if range_is_gap_backed(&self.children[group_start], dest_time, end_time) {
-                return Some(group_start);
-            }
-            let has_blocking_clip = range_has_blocking_clip(
-                &self.children[group_start],
+        // Video-over-audio layout: reuse the video track directly above the audio group.
+        if audio_start > 0 && !track_is_empty_boundary(&self.children[audio_start]) {
+            if let Some(track_index) = self.try_reuse_video_track_for_audio_move(
+                audio_start - 1,
+                audio_track_index,
                 dest_time,
                 end_time,
                 sync_clips_id,
-            );
-            let can_push_existing_boundary = overlap_policy == OverlapPolicy::Push
-                && self.track_matches_primary_sync_boundary(audio_track_index, group_start);
-            if !has_blocking_clip || can_push_existing_boundary {
-                return use_sync_backed_track.then_some(group_start);
+                use_sync_backed_track,
+                overlap_policy,
+            ) {
+                return Some(track_index);
             }
         }
 
+        // Audio-over-video layout: reuse the video track directly below the audio group.
+        if audio_end < self.children.len() {
+            if let Some(track_index) = self.try_reuse_video_track_for_audio_move(
+                audio_end,
+                audio_track_index,
+                dest_time,
+                end_time,
+                sync_clips_id,
+                use_sync_backed_track,
+                overlap_policy,
+            ) {
+                return Some(track_index);
+            }
+        }
+
+        // Create the new video track directly below the moving audio group.
+        let insert_at = audio_end;
         let track = self.new_numbered_track(TrackKind::Video);
-        self.children.insert(group_start, track);
-        created_track_indices.push(group_start);
-        Some(group_start)
+        self.children.insert(insert_at, track);
+        created_track_indices.push(insert_at);
+        Some(insert_at)
     }
 
     fn item_occupies_column(

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -12,6 +12,8 @@ mod stack_item_replace;
 mod stack_item_split;
 mod stack_track;
 
+use stack_item_split::SyncSplitIdPolicy;
+
 const EPS: Seconds = 1e-9;
 /// Fallback frame rate when OTIO stores timeline positions with `rate: 1.0` (seconds).
 const DEFAULT_SYNC_FRAME_RATE: f64 = 24.0;
@@ -240,6 +242,56 @@ impl Stack {
             InsertPolicy::InsertBefore,
         );
         true
+    }
+
+    fn prepare_sync_splits_for_insert(
+        &mut self,
+        track_index: usize,
+        insert_time: Seconds,
+        item_duration: Seconds,
+        insert_policy: InsertPolicy,
+        overlap_policy: OverlapPolicy,
+    ) {
+        let Some(start) = insertion_start_or_end_for_policy(
+            &self.children[track_index],
+            insert_time,
+            insert_policy,
+        ) else {
+            return;
+        };
+        if matches!(insert_policy, InsertPolicy::SplitAndInsert) {
+            let _ = self.split_sync_clips_at_time(start, SyncSplitIdPolicy::KeepShared);
+        }
+        if overlap_policy == OverlapPolicy::Override && item_duration > EPS {
+            let _ = self.split_sync_clips_at_time(start, SyncSplitIdPolicy::KeepShared);
+            let _ = self.split_sync_clips_at_time(
+                start + item_duration,
+                SyncSplitIdPolicy::KeepShared,
+            );
+        }
+    }
+
+    fn insert_at_time_with_sync_splits(
+        &mut self,
+        track_index: usize,
+        insert_time: Seconds,
+        item: Item,
+        overlap_policy: OverlapPolicy,
+        insert_policy: InsertPolicy,
+    ) {
+        self.prepare_sync_splits_for_insert(
+            track_index,
+            insert_time,
+            item.duration().max(0.0),
+            insert_policy,
+            overlap_policy,
+        );
+        self.children[track_index].insert_at_time(
+            insert_time,
+            item,
+            overlap_policy,
+            insert_policy,
+        );
     }
 
     fn find_or_create_audio_track(
@@ -2443,7 +2495,8 @@ impl Stack {
                     *self = backup;
                     return false;
                 };
-                self.children[target_track_index].insert_at_time(
+                self.insert_at_time_with_sync_splits(
+                    target_track_index,
                     item_destination_time,
                     item,
                     overlap_policy,
@@ -2453,7 +2506,8 @@ impl Stack {
         }
 
         if linked_audio_items.is_empty() {
-            self.children[dest_track_index].insert_at_time(
+            self.insert_at_time_with_sync_splits(
+                dest_track_index,
                 dest_time,
                 item_to_move,
                 overlap_policy,
@@ -2712,6 +2766,32 @@ impl Stack {
             placements.push((track_index, gap, false));
         }
         placements.sort_by_key(|(track_index, _, _)| *track_index);
+
+        let insert_policy = match placement {
+            SyncedMovePlacement::Time { insert_policy, .. } => insert_policy,
+            SyncedMovePlacement::Index { .. } => InsertPolicy::SplitAndInsert,
+        };
+        let mut split_times = Vec::new();
+        if matches!(insert_policy, InsertPolicy::SplitAndInsert) {
+            split_times.push(moved_start);
+        }
+        if overlap_policy == OverlapPolicy::Override && moved_duration > EPS {
+            if !split_times
+                .iter()
+                .any(|time| (*time - moved_start).abs() <= EPS)
+            {
+                split_times.push(moved_start);
+            }
+            split_times.push(moved_start + moved_duration);
+        }
+        split_times.sort_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
+        split_times.dedup_by(|left, right| (*left - *right).abs() <= EPS);
+        for split_time in split_times {
+            if !self.split_sync_clips_at_time(split_time, SyncSplitIdPolicy::KeepShared) {
+                *self = backup;
+                return false;
+            }
+        }
 
         for (track_index, item, is_selected) in placements {
             if is_selected {

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -2236,6 +2236,21 @@ impl Stack {
         Some(items)
     }
 
+    fn is_intra_cluster_sync_move(
+        &self,
+        dest_track_index: usize,
+        items_to_move: &[SyncedMoveItem],
+    ) -> bool {
+        let cluster: HashSet<usize> = self
+            .boundary_group_indices(dest_track_index)
+            .into_iter()
+            .collect();
+        cluster.contains(&dest_track_index)
+            && items_to_move
+                .iter()
+                .all(|item| cluster.contains(&item.track_index))
+    }
+
     fn stack_item_start_time(&self, item_id: &str) -> Option<Seconds> {
         let (track_index, item_index, _) = self.get_item(item_id)?;
         Some(self.children[track_index].start_time_of_item(item_index))
@@ -2509,6 +2524,9 @@ impl Stack {
             TrackKind::Other => {}
         }
 
+        let intra_cluster_move =
+            backup.is_intra_cluster_sync_move(dest_track_index, &items_to_move);
+
         let mut sync_track_items: Vec<_> = items_to_move
             .into_iter()
             .enumerate()
@@ -2522,6 +2540,19 @@ impl Stack {
         });
 
         for (_, move_item) in sync_track_items {
+            if intra_cluster_move {
+                let track_index = move_item.track_index;
+                match move_item.track_kind {
+                    TrackKind::Audio => used_audio_track_indices.push(track_index),
+                    TrackKind::Video => used_video_track_indices.push(track_index),
+                    TrackKind::Other => {
+                        *self = backup;
+                        return false;
+                    }
+                }
+                placements.push((track_index, move_item.item, false));
+                continue;
+            }
 
             match move_item.track_kind {
                 TrackKind::Audio => {

--- a/tellers-timeline-core/src/stack_methods/stack_item_split.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_item_split.rs
@@ -2,6 +2,12 @@ use crate::{Item, Seconds, Stack};
 
 const EPS: Seconds = super::EPS;
 
+#[derive(Copy, Clone)]
+pub(super) enum SyncSplitIdPolicy {
+    KeepShared,
+    AssignNewIdToRight,
+}
+
 impl Stack {
     pub fn split_item_at_time(&mut self, item_id: &str, split_time: Seconds) -> bool {
         let Some((selected_track_index, selected_item_index, selected_item)) =
@@ -24,34 +30,117 @@ impl Stack {
         }
 
         let selected_sync_clips_id = super::resolve_sync_clips_id(&selected_clip.metadata);
-        let targets = selected_sync_clips_id
-            .map(|sync_clips_id| self.synced_clips_targets(sync_clips_id))
-            .filter(|targets| targets.len() > 1)
-            .unwrap_or_else(|| vec![(selected_track_index, selected_item_index)]);
+        if let Some(sync_clips_id) = selected_sync_clips_id {
+            let targets = self.synced_clips_targets(sync_clips_id);
+            if targets.len() > 1 {
+                let ok = self.split_sync_clips_group_at_time(
+                    sync_clips_id,
+                    split_time,
+                    SyncSplitIdPolicy::AssignNewIdToRight,
+                    true,
+                );
+                if ok {
+                    self.sanitize();
+                }
+                return ok;
+            }
+        }
+
+        self.children[selected_track_index].split_at_time(split_time);
+        self.sanitize();
+        true
+    }
+
+    /// Split every synced clip in a link group that strictly contains `split_time`.
+    pub(super) fn split_sync_clips_at_time(
+        &mut self,
+        split_time: Seconds,
+        id_policy: SyncSplitIdPolicy,
+    ) -> bool {
+        let mut sync_ids = std::collections::HashSet::new();
+        for track in &self.children {
+            let Some(item_index) = track.get_item_at_time(split_time) else {
+                continue;
+            };
+            let item_start = track.start_time_of_item(item_index);
+            let item = &track.items[item_index];
+            let Item::Clip(clip) = item else {
+                continue;
+            };
+            if split_time <= item_start + EPS || split_time >= item_start + item.duration() - EPS {
+                continue;
+            }
+            if let Some(sync_id) = super::resolve_sync_clips_id(&clip.metadata) {
+                sync_ids.insert(sync_id);
+            }
+        }
+        if sync_ids.is_empty() {
+            return true;
+        }
+
         let backup = self.clone();
+        for sync_clips_id in sync_ids {
+            if !self.split_sync_clips_group_at_time(
+                sync_clips_id,
+                split_time,
+                id_policy,
+                false,
+            ) {
+                *self = backup;
+                return false;
+            }
+        }
+        true
+    }
+
+    fn split_sync_clips_group_at_time(
+        &mut self,
+        sync_clips_id: i64,
+        split_time: Seconds,
+        id_policy: SyncSplitIdPolicy,
+        require_all_targets: bool,
+    ) -> bool {
+        let targets = self.synced_clips_targets(sync_clips_id);
+        if targets.len() <= 1 {
+            return true;
+        }
+
+        let mut splittable = Vec::new();
         for (track_index, item_index) in &targets {
             let Some(item) = self
                 .children
                 .get(*track_index)
                 .and_then(|track| track.items.get(*item_index))
             else {
-                *self = backup;
                 return false;
             };
             let Item::Clip(clip) = item else {
-                *self = backup;
-                return false;
+                if require_all_targets {
+                    return false;
+                }
+                continue;
             };
             let item_start = self.children[*track_index].start_time_of_item(*item_index);
             let item_end = item_start + clip.source_range.duration.to_seconds().max(0.0);
             if split_time <= item_start + EPS || split_time >= item_end - EPS {
-                *self = backup;
-                return false;
+                if require_all_targets {
+                    return false;
+                }
+                continue;
             }
+            splittable.push((*track_index, *item_index));
         }
 
-        let right_sync_clips_id = (targets.len() > 1).then(|| self.next_sync_clips_id());
-        let mut target_tracks: Vec<_> = targets
+        if splittable.is_empty() {
+            return true;
+        }
+        if require_all_targets && splittable.len() != targets.len() {
+            return false;
+        }
+
+        let right_sync_clips_id = matches!(id_policy, SyncSplitIdPolicy::AssignNewIdToRight)
+            .then(|| self.next_sync_clips_id());
+        let mut target_tracks: Vec<_> = splittable
             .iter()
             .map(|(track_index, _)| *track_index)
             .collect();
@@ -61,19 +150,17 @@ impl Stack {
             self.children[track_index].split_at_time(split_time);
         }
         if let Some(sync_clips_id) = right_sync_clips_id {
-            for (track_index, item_index) in &targets {
+            for (track_index, item_index) in &splittable {
                 let Some(Item::Clip(clip)) = self
                     .children
                     .get_mut(*track_index)
                     .and_then(|track| track.items.get_mut(item_index + 1))
                 else {
-                    *self = backup;
                     return false;
                 };
                 super::set_resolve_sync_clips_id(&mut clip.metadata, sync_clips_id);
             }
         }
-        self.sanitize();
         true
     }
 }

--- a/tellers-timeline-core/tests/synced.rs
+++ b/tellers-timeline-core/tests/synced.rs
@@ -1855,6 +1855,65 @@ fn move_synced_set_on_same_track_in_cluster_preserves_track_and_cluster_count() 
 }
 
 #[test]
+fn move_synced_set_within_same_cluster_preserves_original_tracks_when_moving_from_audio() {
+    let mut stack = Stack::default();
+
+    for id in ["A1", "A2", "A3"] {
+        let mut audio = Track::new(TrackKind::Audio, Some(id.to_string()));
+        audio.items.push(synced_clip_item_with_rate(
+            62.88,
+            0.0,
+            &format!("{id}-g3"),
+            3,
+            25.0,
+        ));
+        stack.children.push(audio);
+    }
+
+    let mut video = Track::new(TrackKind::Video, Some("video".to_string()));
+    video.items.push(synced_clip_item_with_rate(62.88, 0.0, "v-g3", 3, 25.0));
+    stack.children.push(video);
+
+    let video_track_before = stack.get_track_by_id("video").unwrap().0;
+    let track_count = stack.children.len();
+
+    assert!(stack.move_item_at_time(
+        "A1-g3",
+        "A1",
+        4.0,
+        true,
+        InsertPolicy::SplitAndInsert,
+        OverlapPolicy::Override,
+    ));
+
+    assert_eq!(stack.children.len(), track_count);
+    let (video_track, video_index, _) = stack.get_item("v-g3").unwrap();
+    assert_eq!(
+        video_track, video_track_before,
+        "video must stay on its original track when moving within the sync cluster"
+    );
+    assert_eq!(
+        stack.children[video_track].get_id().as_deref(),
+        Some("video")
+    );
+    assert_eq!(
+        stack.children[video_track].start_time_of_item(video_index),
+        4.0
+    );
+    for (id, track_id) in [("A1-g3", "A1"), ("A2-g3", "A2"), ("A3-g3", "A3")] {
+        let (audio_track, audio_index, _) = stack.get_item(id).unwrap();
+        assert_eq!(
+            stack.children[audio_track].get_id().as_deref(),
+            Some(track_id)
+        );
+        assert_eq!(
+            stack.children[audio_track].start_time_of_item(audio_index),
+            4.0
+        );
+    }
+}
+
+#[test]
 fn move_unsynced_clip_between_video_tracks_in_cluster_preserves_track_and_cluster_count() {
     let mut stack = Stack::default();
 

--- a/tellers-timeline-core/tests/synced.rs
+++ b/tellers-timeline-core/tests/synced.rs
@@ -1914,6 +1914,65 @@ fn move_synced_set_within_same_cluster_preserves_original_tracks_when_moving_fro
 }
 
 #[test]
+fn move_synced_audio_creates_video_track_below_audio_group_in_resolve_layout() {
+    let mut stack = Stack::default();
+    const DUR: f64 = 5.0;
+
+    let mut a15 = Track::new(TrackKind::Audio, Some("A15".to_string()));
+    a15.items.push(Item::Gap(Gap::make_gap(100.0)));
+    let mut aud = audio_clip(DUR, "file:///moving-aud.wav", None);
+    aud.set_id(Some("moving-aud".to_string()));
+    a15.items.push(aud);
+
+    let mut v1 = Track::new(TrackKind::Video, Some("V1".to_string()));
+    v1.items.push(Item::Gap(Gap::make_gap(100.0)));
+    v1.items
+        .push(Item::Clip(clip(DUR, Some("moving-vid"))));
+
+    stack.children.push(a15);
+    stack.children.push(v1);
+    stack
+        .sync_item(&["moving-vid".to_string(), "moving-aud".to_string()])
+        .unwrap();
+
+    let mut separator = Track::new(TrackKind::Video, Some("separator-v".to_string()));
+    separator
+        .items
+        .push(Item::Clip(clip(100.0, Some("separator-vid"))));
+    stack.children.push(separator);
+
+    let mut dest_a = Track::new(TrackKind::Audio, Some("dest-a".to_string()));
+    dest_a.items.push(Item::Gap(Gap::make_gap(100.0)));
+    stack.children.push(dest_a);
+
+    let dest_a_index = stack.get_track_by_id("dest-a").unwrap().0;
+    let v1_index = stack.get_track_by_id("V1").unwrap().0;
+    let track_count_before = stack.children.len();
+
+    assert!(stack.move_item_at_time(
+        "moving-aud",
+        "dest-a",
+        50.0,
+        true,
+        InsertPolicy::SplitAndInsert,
+        OverlapPolicy::Override,
+    ));
+
+    assert_eq!(stack.children.len(), track_count_before + 1);
+    let (video_track, video_index, _) = stack.get_item("moving-vid").unwrap();
+    assert_eq!(stack.children[video_track].kind, TrackKind::Video);
+    assert_eq!(
+        video_track, dest_a_index + 1,
+        "new video track must sit directly below dest-a, not at stack top or next to V1"
+    );
+    assert_eq!(stack.get_track_by_id("V1").unwrap().0, v1_index);
+    assert_eq!(
+        stack.children[video_track].start_time_of_item(video_index),
+        50.0
+    );
+}
+
+#[test]
 fn move_unsynced_clip_between_video_tracks_in_cluster_preserves_track_and_cluster_count() {
     let mut stack = Stack::default();
 

--- a/tellers-timeline-core/tests/synced.rs
+++ b/tellers-timeline-core/tests/synced.rs
@@ -6006,6 +6006,67 @@ fn move_synced_set_splits_other_synced_clips_on_all_tracks() {
 }
 
 #[test]
+fn move_synced_clip_with_reused_link_group_id_splits_long_column_on_video() {
+    const SHORT: f64 = 3.84;
+    const GAP_MID: f64 = 5.0;
+    const LONG: f64 = 54.08;
+    const LEAD: f64 = 5.0;
+    const SYNC_ID: i64 = 1;
+
+    let mut stack = Stack::default();
+    let mut a15 = Track::new(TrackKind::Audio, Some("A15".to_string()));
+    a15.items.push(Item::Gap(Gap::make_gap(LEAD)));
+    a15.items.push(synced_clip_item(SHORT, "short-audio", SYNC_ID));
+    a15.items.push(Item::Gap(Gap::make_gap(GAP_MID)));
+    a15.items.push(synced_clip_item(LONG, "long-audio", SYNC_ID));
+
+    let mut v1 = Track::new(TrackKind::Video, Some("V1".to_string()));
+    v1.items.push(Item::Gap(Gap::make_gap(LEAD)));
+    v1.items.push(synced_clip_item(SHORT, "short-video", SYNC_ID));
+    v1.items.push(Item::Clip(clip(GAP_MID, Some("screenshot"))));
+    v1.items.push(synced_clip_item(LONG, "long-video", SYNC_ID));
+
+    stack.children.push(a15);
+    stack.children.push(v1);
+
+    assert!(stack.move_item_at_time(
+        "short-audio",
+        "A15",
+        20.0,
+        true,
+        InsertPolicy::SplitAndInsert,
+        OverlapPolicy::Override,
+    ));
+
+    let (_, video_track) = stack.get_track_by_id("V1").unwrap();
+    let (_, short_video_index, _) = stack.get_item("short-video").unwrap();
+    assert!(
+        (video_track.start_time_of_item(short_video_index) - 20.0).abs() < 1e-6,
+        "short video partner should land at the move destination"
+    );
+    let (_, long_video_index, _) = stack.get_item("long-video").unwrap();
+    assert!((video_track.start_time_of_item(long_video_index) - 13.84).abs() < 1e-2);
+    assert!((video_track.items[long_video_index].duration() - 6.16).abs() < 1e-2);
+    let long_video_tail = video_track
+        .items
+        .get(long_video_index + 2)
+        .expect("long synced video tail after moved short clip");
+    let expected_tail = LONG - (20.0 - 13.84) - SHORT;
+    assert!(
+        (long_video_tail.duration() - expected_tail).abs() < 1e-2,
+        "tail duration {} expected {}",
+        long_video_tail.duration(),
+        expected_tail
+    );
+
+    let (_, audio_track) = stack.get_track_by_id("A15").unwrap();
+    let (_, short_audio_index, _) = stack.get_item("short-audio").unwrap();
+    assert!((audio_track.start_time_of_item(short_audio_index) - 20.0).abs() < 1e-6);
+    let (_, long_audio_index, _) = stack.get_item("long-audio").unwrap();
+    assert!((audio_track.items[long_audio_index].duration() - 6.16).abs() < 1e-2);
+}
+
+#[test]
 fn add_synced_clip_with_multiple_audio_into_two_synced_clips() {
     let times = [0.0_f64, 2.0, 3.0, 4.0, 6.0, 8.0];
     let overlaps = [OverlapPolicy::Override, OverlapPolicy::Push];

--- a/tellers-timeline-core/tests/synced.rs
+++ b/tellers-timeline-core/tests/synced.rs
@@ -6067,6 +6067,63 @@ fn move_synced_clip_with_reused_link_group_id_splits_long_column_on_video() {
 }
 
 #[test]
+fn move_unsynced_image_into_synced_clip_override_assigns_new_link_group_to_right() {
+    const SYNC_ID: i64 = 2;
+    const SYNC_DUR: f64 = 42.0;
+    const IMAGE_DUR: f64 = 5.0;
+    const LEAD: f64 = 5.0;
+
+    let mut audio = Track::new(TrackKind::Audio, Some("A3".to_string()));
+    audio.items.push(Item::Gap(Gap::make_gap(LEAD)));
+    audio.items.push(synced_clip_item(SYNC_DUR, "sync-audio", SYNC_ID));
+
+    let mut video = Track::new(TrackKind::Video, Some("v".to_string()));
+    video.items.push(Item::Gap(Gap::make_gap(LEAD)));
+    video.items.push(synced_clip_item(SYNC_DUR, "sync-video", SYNC_ID));
+    video
+        .items
+        .push(Item::Clip(clip(IMAGE_DUR, Some("screenshot"))));
+
+    let mut stack = Stack::default();
+    stack.children.push(audio);
+    stack.children.push(video);
+
+    assert!(stack.move_item_at_time(
+        "screenshot",
+        "v",
+        20.0,
+        true,
+        InsertPolicy::SplitAndInsert,
+        OverlapPolicy::Override,
+    ));
+
+    assert_eq!(
+        sync_clips_id(stack.get_item("sync-video").unwrap().2),
+        Some(SYNC_ID)
+    );
+
+    let (_, video_track) = stack.get_track_by_id("v").unwrap();
+    let sync_group_ids: Vec<_> = video_track
+        .items
+        .iter()
+        .filter_map(sync_clips_id)
+        .collect();
+    assert_eq!(sync_group_ids, vec![SYNC_ID, SYNC_ID + 1]);
+    assert_eq!(
+        sync_clips_id(stack.get_item("screenshot").unwrap().2),
+        None
+    );
+
+    let (_, audio_track) = stack.get_track_by_id("A3").unwrap();
+    let audio_sync_group_ids: Vec<_> = audio_track
+        .items
+        .iter()
+        .filter_map(sync_clips_id)
+        .collect();
+    assert_eq!(audio_sync_group_ids, vec![SYNC_ID, SYNC_ID + 1]);
+}
+
+#[test]
 fn add_synced_clip_with_multiple_audio_into_two_synced_clips() {
     let times = [0.0_f64, 2.0, 3.0, 4.0, 6.0, 8.0];
     let overlaps = [OverlapPolicy::Override, OverlapPolicy::Push];

--- a/tellers-timeline-core/tests/synced.rs
+++ b/tellers-timeline-core/tests/synced.rs
@@ -5946,6 +5946,66 @@ fn move_synced_group_reuses_audio_track_below_without_creating_track() {
 }
 
 #[test]
+fn move_synced_set_splits_other_synced_clips_on_all_tracks() {
+    let mut stack = Stack::default();
+    let mut video = Track::new(TrackKind::Video, Some("v".to_string()));
+    video
+        .items
+        .push(Item::Clip(clip(10.0, Some("long-video"))));
+    let mut audio = Track::new(TrackKind::Audio, Some("a".to_string()));
+    let mut long_audio = audio_clip(10.0, "file:///long-audio.wav", None);
+    long_audio.set_id(Some("long-audio".to_string()));
+    audio.items.push(long_audio);
+
+    stack.children.push(video);
+    stack.children.push(audio);
+    stack
+        .sync_item(&["long-video".to_string(), "long-audio".to_string()])
+        .unwrap();
+    let long_group = sync_clips_id(stack.get_item("long-video").unwrap().2);
+
+    stack.children[0]
+        .items
+        .push(Item::Clip(clip(3.0, Some("moving-video"))));
+    let mut moving_audio = audio_clip(3.0, "file:///moving-audio.wav", None);
+    moving_audio.set_id(Some("moving-audio".to_string()));
+    stack.children[1].items.push(moving_audio);
+    stack
+        .sync_item(&["moving-video".to_string(), "moving-audio".to_string()])
+        .unwrap();
+    let moving_group = sync_clips_id(stack.get_item("moving-video").unwrap().2);
+
+    assert!(stack.move_item_at_time(
+        "moving-audio",
+        "a",
+        5.0,
+        true,
+        InsertPolicy::SplitAndInsert,
+        OverlapPolicy::Override,
+    ));
+
+    let video = &stack.children[0];
+    assert_eq!(video.items.len(), 3);
+    assert_eq!(video.items[0].duration(), 5.0);
+    assert_eq!(sync_clips_id(&video.items[0]), long_group);
+    assert_eq!(video.items[1].duration(), 3.0);
+    assert_eq!(sync_clips_id(&video.items[1]), moving_group);
+    assert_eq!(video.items[2].duration(), 2.0);
+    assert_eq!(sync_clips_id(&video.items[2]), long_group);
+
+    let audio = &stack.children[1];
+    assert_eq!(audio.items.len(), 3);
+    assert_eq!(audio.items[0].duration(), 5.0);
+    assert_eq!(sync_clips_id(&audio.items[0]), long_group);
+    assert_eq!(audio.items[0].get_id().as_deref(), Some("long-audio"));
+    assert_eq!(audio.items[1].duration(), 3.0);
+    assert_eq!(sync_clips_id(&audio.items[1]), moving_group);
+    assert_eq!(audio.items[1].get_id().as_deref(), Some("moving-audio"));
+    assert_eq!(audio.items[2].duration(), 2.0);
+    assert_eq!(sync_clips_id(&audio.items[2]), long_group);
+}
+
+#[test]
 fn add_synced_clip_with_multiple_audio_into_two_synced_clips() {
     let times = [0.0_f64, 2.0, 3.0, 4.0, 6.0, 8.0];
     let overlaps = [OverlapPolicy::Override, OverlapPolicy::Push];


### PR DESCRIPTION
## Summary
- Fixes a bug where moving a synced clip within the same sync cluster (e.g. dragging an audio sync partner to a new time) could relocate the video clip to a newly created track instead of keeping it on its original video track.
- Detects intra-cluster synced moves from the pre-move backup and reuses each partner's original track index; cross-cluster moves still use the existing find-or-create routing.
- Adds a regression test for the common Resolve layout (audio tracks above video).

## Test plan
- [x] `cargo test -p tellers-timeline-core --test synced move_synced_set_within_same_cluster_preserves_original_tracks_when_moving_from_audio`
- [x] `cargo test -p tellers-timeline-core --test synced move_synced`
- [x] `cargo test -p tellers-timeline-core --test synced --test move`


Made with [Cursor](https://cursor.com)