### PR TITLE
Rework stack collapse delete and add track delete_range helper

### DIFF
--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -754,16 +754,7 @@ impl Stack {
             Item::Gap(_) => None,
         };
         if let Some(sync_id) = sync_clips_id {
-            let column_start = self.children[track_index].start_time_of_item(item_index);
-            let column_duration = item.duration().max(0.0);
-            Some(
-                self.synced_clips_targets(sync_id)
-                    .into_iter()
-                    .filter(|(ti, ii)| {
-                        self.item_occupies_column(*ti, *ii, column_start, column_duration)
-                    })
-                    .collect(),
-            )
+            Some(self.synced_clips_targets(sync_id))
         } else {
             Some(vec![(track_index, item_index)])
         }
@@ -818,17 +809,6 @@ impl Stack {
 
         if matches!(item, Item::Gap(_)) {
             let removed = self.delete_clips_at_indices(vec![(track_index, item_index)], false);
-            if !removed.is_empty() {
-                self.sanitize();
-            }
-            return removed;
-        }
-
-        if item.duration() <= EPS {
-            let removed: Vec<_> = self
-                .delete_one_item(item_id, false)
-                .into_iter()
-                .collect();
             if !removed.is_empty() {
                 self.sanitize();
             }

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -717,10 +717,9 @@ impl Stack {
             if ii >= track.items.len() {
                 continue;
             }
-            let removed_item = track.items[ii].clone();
-            if !track.delete_clip_at(ii, replace_with_gap) {
+            let Some(removed_item) = track.delete_clip_at(ii, replace_with_gap) else {
                 continue;
-            }
+            };
             if replace_with_gap {
                 if let (Some(used_ids), Some(item)) = (&mut used_ids, track.items.get_mut(ii)) {
                     if matches!(item, Item::Gap(_)) {
@@ -2355,26 +2354,23 @@ impl Stack {
             if let Some((ii, _)) = self.children[ti].get_item_by_id(item_id) {
                 let backup = self.clone();
                 let before_states = self.synced_clip_states();
-                let removed = self.children[ti].items[ii].clone();
                 // Use the track API for deletion and optional gap insertion/merge behavior
-                let deleted = self.children[ti].delete_clip(ii, replace_with_gap);
-                if deleted {
-                    if !replace_with_gap {
-                        let excluded_ids = removed.get_id().into_iter().collect();
-                        if !self.sync_changed_groups_after_resize(
-                            &before_states,
-                            &[ti],
-                            &excluded_ids,
-                            OverlapPolicy::Override,
-                        ) {
-                            *self = backup;
-                            return None;
-                        }
-                    }
-                    return Some((ti, removed));
-                } else {
+                let Some(removed) = self.children[ti].delete_clip(ii, replace_with_gap) else {
                     return None;
+                };
+                if !replace_with_gap {
+                    let excluded_ids = removed.get_id().into_iter().collect();
+                    if !self.sync_changed_groups_after_resize(
+                        &before_states,
+                        &[ti],
+                        &excluded_ids,
+                        OverlapPolicy::Override,
+                    ) {
+                        *self = backup;
+                        return None;
+                    }
                 }
+                return Some((ti, removed));
             }
         }
         None

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -717,11 +717,22 @@ impl Stack {
             if ii >= track.items.len() {
                 continue;
             }
-            let Some(removed_item) = track.delete_clip_at(ii, replace_with_gap) else {
+            if matches!(track.items[ii], Item::Gap(_)) && replace_with_gap {
+                continue;
+            }
+            let start = track.start_time_of_item(ii);
+            let end = start + track.items[ii].duration().max(0.0);
+            let mut removed_items = track.delete_range(start, end, replace_with_gap);
+            let Some(removed_item) = removed_items.pop() else {
                 continue;
             };
             if replace_with_gap {
-                if let (Some(used_ids), Some(item)) = (&mut used_ids, track.items.get_mut(ii)) {
+                if let (Some(used_ids), Some(item)) = (
+                    &mut used_ids,
+                    track
+                        .get_item_at_time(start)
+                        .and_then(|gap_index| track.items.get_mut(gap_index)),
+                ) {
                     if matches!(item, Item::Gap(_)) {
                         Self::ensure_unique_item_id(item, used_ids);
                     }
@@ -769,6 +780,37 @@ impl Stack {
         removed
     }
 
+    fn sync_groups_behind_clips(&self, clips_to_delete: &[(usize, usize)]) -> HashSet<i64> {
+        let mut sync_groups = HashSet::new();
+        for &(ti, ii) in clips_to_delete {
+            let Some(track) = self.children.get(ti) else {
+                continue;
+            };
+            for item in track.items.iter().skip(ii + 1) {
+                if let Item::Clip(clip) = item {
+                    if let Some(sync_id) = resolve_sync_clips_id(&clip.metadata) {
+                        sync_groups.insert(sync_id);
+                    }
+                }
+            }
+        }
+        sync_groups
+    }
+
+    fn collapse_mutation_tracks(
+        &self,
+        clips_to_delete: &[(usize, usize)],
+        sync_groups_behind: &HashSet<i64>,
+    ) -> HashSet<usize> {
+        let mut tracks: HashSet<usize> = clips_to_delete.iter().map(|(ti, _)| *ti).collect();
+        for sync_id in sync_groups_behind {
+            for (ti, _) in self.synced_clips_targets(*sync_id) {
+                tracks.insert(ti);
+            }
+        }
+        tracks
+    }
+
     fn delete_item_collapse(&mut self, item_id: &str) -> Vec<(usize, Item)> {
         let Some((track_index, item_index, item)) = self.get_item(item_id) else {
             return Vec::new();
@@ -793,66 +835,38 @@ impl Stack {
             return removed;
         }
 
-        let column_start = self.children[track_index].start_time_of_item(item_index);
-        let column_duration = item.duration().max(0.0);
-        let linked_tracks = self.boundary_group_indices(track_index);
-        let sync_clips_id = match &item {
-            Item::Clip(clip) => resolve_sync_clips_id(&clip.metadata),
-            Item::Gap(_) => None,
+        let Some(clips_to_delete) = self.delete_item_targets(item_id) else {
+            return Vec::new();
         };
+        if clips_to_delete.is_empty() {
+            return Vec::new();
+        }
 
-        let backup = self.clone();
-        let mut clips_to_delete = Vec::new();
-        let mut covered_tracks = HashSet::new();
+        let column_start = self.children[track_index].start_time_of_item(item_index);
+        let column_end = column_start + item.duration().max(0.0);
+        let sync_groups_behind = self.sync_groups_behind_clips(&clips_to_delete);
+        let tracks_to_mutate =
+            self.collapse_mutation_tracks(&clips_to_delete, &sync_groups_behind);
 
-        for &ti in &linked_tracks {
-            let Some(ii) = self.item_at_column(ti, column_start, column_duration) else {
+        let mut removed = self.delete_clips_at_indices(clips_to_delete, false);
+        let mutated_tracks: HashSet<usize> = removed.iter().map(|(ti, _)| *ti).collect();
+
+        let mut pending_range_tracks: Vec<_> = tracks_to_mutate
+            .into_iter()
+            .filter(|ti| !mutated_tracks.contains(ti))
+            .collect();
+        pending_range_tracks.sort_unstable();
+        pending_range_tracks.dedup();
+
+        for ti in pending_range_tracks {
+            let Some(track) = self.children.get_mut(ti) else {
                 continue;
             };
-            let column_item = &self.children[ti].items[ii];
-            let is_target = column_item.get_id().as_deref() == Some(item_id);
-            let is_synced = sync_clips_id.is_some_and(|sync_id| {
-                matches!(
-                    column_item,
-                    Item::Clip(clip) if resolve_sync_clips_id(&clip.metadata) == Some(sync_id)
-                )
-            });
-            if is_target || is_synced {
-                clips_to_delete.push((ti, ii));
-                covered_tracks.insert(ti);
+            for removed_item in track.delete_range(column_start, column_end, false) {
+                removed.push((ti, removed_item));
             }
         }
 
-        if covered_tracks.len() < linked_tracks.len() {
-            let mut used_ids = self.collect_timeline_ids();
-            for &ti in &linked_tracks {
-                if covered_tracks.contains(&ti) {
-                    continue;
-                }
-                if let Some(ii) = self.item_at_column(ti, column_start, column_duration) {
-                    let column_item = &self.children[ti].items[ii];
-                    if matches!(column_item, Item::Gap(_)) || Self::item_is_unsynced(column_item) {
-                        clips_to_delete.push((ti, ii));
-                        covered_tracks.insert(ti);
-                        continue;
-                    }
-                }
-                let mut gap = Item::Gap(Gap::make_gap(column_duration));
-                Self::ensure_unique_item_id(&mut gap, &mut used_ids);
-                if !self.insert_gap_only(ti, column_start, gap) {
-                    *self = backup;
-                    return Vec::new();
-                }
-                let Some(ii) = self.item_at_column(ti, column_start, column_duration) else {
-                    *self = backup;
-                    return Vec::new();
-                };
-                clips_to_delete.push((ti, ii));
-                covered_tracks.insert(ti);
-            }
-        }
-
-        let removed = self.delete_clips_at_indices(clips_to_delete, false);
         if !removed.is_empty() {
             self.sanitize();
         }

--- a/tellers-timeline-core/src/track_methods/track_item_delete.rs
+++ b/tellers-timeline-core/src/track_methods/track_item_delete.rs
@@ -1,4 +1,4 @@
-use crate::{Item, Track};
+use crate::{Item, Seconds, Track};
 
 impl Track {
     /// Remove the clip or gap at `index`, optionally inserting a gap of the same
@@ -24,6 +24,45 @@ impl Track {
             Item::Gap(_) if !replace_with_gap => Some(self.items.remove(index)),
             Item::Gap(_) => None,
         }
+    }
+
+    /// Delete every item fully contained in `[start_time, end_time)`.
+    /// Clips overlapping the boundaries are split first. When `replace_with_gap` is true,
+    /// a gap of the deleted span duration is inserted at `start_time`.
+    /// Does not run track sanitize; callers batch sanitize at the stack level.
+    pub(crate) fn delete_range(
+        &mut self,
+        start_time: Seconds,
+        end_time: Seconds,
+        replace_with_gap: bool,
+    ) -> Vec<Item> {
+        const EPS: Seconds = 1e-9;
+        let start = start_time.max(0.0);
+        let end = end_time.max(start);
+        if end <= start + EPS {
+            return Vec::new();
+        }
+
+        self.split_at_time(start);
+        self.split_at_time(end);
+
+        let start_index = self.get_item_at_time(start).unwrap_or(self.items.len());
+        let end_index = self.get_item_at_time(end).unwrap_or(self.items.len());
+        let removed = if end_index > start_index {
+            self.items.drain(start_index..end_index).collect()
+        } else {
+            Vec::new()
+        };
+
+        if replace_with_gap && end - start > EPS {
+            self.items.insert(
+                start_index,
+                Item::Gap(crate::types::Gap::make_gap(end - start)),
+            );
+            self.merge_adjacent_gaps();
+        }
+
+        removed
     }
 
     /// Delete the clip at a given index. If `replace_with_gap` is true, insert a gap of the
@@ -90,5 +129,47 @@ mod tests {
 
         assert_eq!(track.items.len(), 1);
         assert!(matches!(track.items[0], Item::Clip(_)));
+    }
+
+    #[test]
+    fn delete_range_collapses_spanning_items() {
+        let mut track = Track::default();
+        track.items.push(clip(2.0));
+        track.items.push(clip(3.0));
+        track.items.push(clip(4.0));
+
+        let removed = track.delete_range(1.0, 6.0, false);
+        assert_eq!(removed.len(), 3);
+        assert_eq!(track.items.len(), 2);
+        track.sanitize();
+        assert!((track.total_duration() - 4.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn delete_range_replace_with_gap_preserves_timeline_duration() {
+        let mut track = Track::default();
+        track.items.push(clip(2.0));
+        track.items.push(clip(3.0));
+        track.items.push(clip(4.0));
+
+        let removed = track.delete_range(1.0, 6.0, true);
+        assert_eq!(removed.len(), 3);
+        assert_eq!(track.items.len(), 3);
+        track.sanitize();
+        assert!((track.total_duration() - 9.0).abs() < 1e-9);
+        assert!(matches!(track.items[1], Item::Gap(_)));
+    }
+
+    #[test]
+    fn delete_range_splits_partial_clip() {
+        let mut track = Track::default();
+        track.items.push(clip(10.0));
+
+        let removed = track.delete_range(2.0, 5.0, false);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(track.items.len(), 2);
+        track.sanitize();
+        assert!((track.items[0].duration() - 2.0).abs() < 1e-9);
+        assert!((track.items[1].duration() - 5.0).abs() < 1e-9);
     }
 }

--- a/tellers-timeline-core/src/track_methods/track_item_delete.rs
+++ b/tellers-timeline-core/src/track_methods/track_item_delete.rs
@@ -3,14 +3,15 @@ use crate::{Item, Track};
 impl Track {
     /// Remove the clip or gap at `index`, optionally inserting a gap of the same
     /// duration. Does not run track sanitize; callers batch sanitize at the stack level.
-    pub(crate) fn delete_clip_at(&mut self, index: usize, replace_with_gap: bool) -> bool {
+    /// Returns the removed item on success.
+    pub(crate) fn delete_clip_at(&mut self, index: usize, replace_with_gap: bool) -> Option<Item> {
         if index >= self.items.len() {
-            return false;
+            return None;
         }
         match &self.items[index] {
             Item::Clip(c) => {
                 let removed_duration = c.source_range.duration.to_seconds().max(0.0);
-                self.items.remove(index);
+                let removed = self.items.remove(index);
                 if replace_with_gap && removed_duration > 0.0 {
                     self.items.insert(
                         index.min(self.items.len()),
@@ -18,26 +19,20 @@ impl Track {
                     );
                     self.merge_adjacent_gaps();
                 }
-                true
+                Some(removed)
             }
-            Item::Gap(_) if !replace_with_gap => {
-                self.items.remove(index);
-                true
-            }
-            Item::Gap(_) => false,
+            Item::Gap(_) if !replace_with_gap => Some(self.items.remove(index)),
+            Item::Gap(_) => None,
         }
     }
 
     /// Delete the clip at a given index. If `replace_with_gap` is true, insert a gap of the
     /// same duration at that position and merge adjacent gaps.
-    /// Returns whether a deletion occurred.
-    pub(crate) fn delete_clip(&mut self, index: usize, replace_with_gap: bool) -> bool {
-        if self.delete_clip_at(index, replace_with_gap) {
-            self.sanitize();
-            true
-        } else {
-            false
-        }
+    /// Returns the removed item on success.
+    pub(crate) fn delete_clip(&mut self, index: usize, replace_with_gap: bool) -> Option<Item> {
+        let removed = self.delete_clip_at(index, replace_with_gap)?;
+        self.sanitize();
+        Some(removed)
     }
 }
 
@@ -91,7 +86,7 @@ mod tests {
         track.items.push(clip(3.0));
         track.items.push(Item::Gap(Gap::make_gap(1.0)));
 
-        assert!(track.delete_clip(1, false));
+        assert!(matches!(track.delete_clip(1, false), Some(Item::Clip(_))));
 
         assert_eq!(track.items.len(), 1);
         assert!(matches!(track.items[0], Item::Clip(_)));

--- a/tellers-timeline-core/tests/synced.rs
+++ b/tellers-timeline-core/tests/synced.rs
@@ -3334,6 +3334,38 @@ fn delete_clip_a_collapse_pulls_synced_partner_left() {
     );
 }
 
+fn stack_v1_c1_c2_a1() -> Stack {
+    let mut video = Track::new(TrackKind::Video, Some("v1".to_string()));
+    video.items.push(synced_clip_item(3.0, "c1", 1));
+    video.items.push(Item::Clip(clip(4.0, Some("c2"))));
+    let mut audio = Track::new(TrackKind::Audio, Some("a1".to_string()));
+    audio.items.push(synced_clip_item(3.0, "c1a", 1));
+    let mut stack = Stack::default();
+    stack.children.push(audio);
+    stack.children.push(video);
+    stack
+}
+
+#[test]
+fn delete_synced_audio_collapse_removes_video_partner_and_moves_following_clip() {
+    let mut stack = stack_v1_c1_c2_a1();
+    let v1 = track_index_by_id(&stack, "v1");
+    let a1 = track_index_by_id(&stack, "a1");
+
+    let removed = stack.delete_item("c1a", false);
+    assert_eq!(removed.len(), 2);
+    assert!(stack.get_item("c1a").is_none());
+    assert!(stack.get_item("c1").is_none());
+    assert!(stack.get_item("c2").is_some());
+
+    let video = &stack.children[v1];
+    assert_eq!(video.items.len(), 1);
+    assert_item_span(video, 0, 0.0, 4.0);
+    assert_eq!(video.items[0].get_id().as_deref(), Some("c2"));
+
+    assert!(stack.children[a1].items.is_empty());
+}
+
 #[test]
 fn delete_unsynced_item_only_removes_selected_item() {
     let mut video = Track::new(TrackKind::Video, Some("v".to_string()));


### PR DESCRIPTION
## Summary
- Add internal `Track::delete_range` helper (split boundaries, remove span, optional gap) and change `delete_clip_at` / `delete_clip` to return `Option<Item>` instead of cloning before deletion.
- Route stack batch deletes through `delete_range`; stack callers use the returned items directly.
- Rework `delete_item_collapse` to plan deletes via link groups instead of sync-track boundary clusters:
  - Resolve all synced clips in the target link group
  - Find sync groups behind any clip being removed and the tracks that need mutation
  - Delete targeted clips, then `delete_range` on partner tracks not already mutated
- Simplify `delete_item_targets` for synced clips to return every clip in the link group (no column filter).
- Add regression test: deleting synced audio `c1a` removes video partner `c1` and pulls following clip `c2` to timeline start.

## Test plan
- [x] `cargo test` in `tellers-timeline-core` (217 tests)
- [x] Delete and synced delete suites, including `delete_synced_audio_collapse_removes_video_partner_and_moves_following_clip`
- [x] `delete_new_project_clip_454bfdad4796_without_gap_collapses_sync_cluster` fixture