### PR TITLE
Propagate stack inserts from track insert results

### DIFF
--- a/tellers-timeline-core/src/sanitize.rs
+++ b/tellers-timeline-core/src/sanitize.rs
@@ -107,7 +107,7 @@ impl Stack {
                 let Item::Clip(clip) = item else {
                     continue;
                 };
-                if let Some(sync_clips_id) = resolve_sync_clips_id(&clip.metadata) {
+                if let Some(sync_clips_id) = clip.sync_clips_id() {
                     *counts.entry(sync_clips_id).or_default() += 1;
                 }
             }
@@ -118,7 +118,7 @@ impl Stack {
                 let Item::Clip(clip) = item else {
                     continue;
                 };
-                let Some(sync_clips_id) = resolve_sync_clips_id(&clip.metadata) else {
+                let Some(sync_clips_id) = clip.sync_clips_id() else {
                     continue;
                 };
                 if counts.get(&sync_clips_id).copied().unwrap_or_default() < 2 {
@@ -146,17 +146,6 @@ fn new_unused_timeline_id(used_ids: &mut HashSet<String>) -> String {
             return id;
         }
     }
-}
-
-fn resolve_sync_clips_id(metadata: &serde_json::Value) -> Option<i64> {
-    metadata
-        .get("Resolve_OTIO")
-        .and_then(|v| v.get("Link Group ID"))
-        .and_then(|v| {
-            v.as_i64()
-                .or_else(|| v.as_u64().and_then(|n| i64::try_from(n).ok()))
-                .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
-        })
 }
 
 fn remove_resolve_sync_clips_id(metadata: &mut serde_json::Value) -> bool {

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     Clip, Gap, IdMetadataExt, InsertPolicy, Item, OverlapPolicy, Seconds, Stack, Track, TrackKind,
+    TrackInsertResult,
 };
 use std::collections::{HashMap, HashSet};
 
@@ -324,15 +325,14 @@ impl Stack {
             insert_policy,
         );
         if primary_result.success {
-            let _ = self.propagate_track_insert_to_cluster(
-                track_index,
+            let updates = [(track_index, &primary_result)];
+            let _ = self.propagate_insert_to_cluster(
                 start,
                 duration,
                 overlap_policy,
-                &primary_result,
+                &updates,
                 &cluster,
                 None,
-                &[],
             );
         }
     }
@@ -1592,6 +1592,30 @@ impl Stack {
             },
         );
 
+        // Moves pass source audio track indices so partners land back on their original
+        // tracks. Empty preferred tracks (no clips, or gaps only) are part of the
+        // destination working cluster so insert propagation applies there too.
+        if let Some(preferred_indices) = preferred_audio_track_indices {
+            for &track_index in preferred_indices {
+                if track_index == dest_track_index {
+                    continue;
+                }
+                let Some(track) = self.children.get(track_index) else {
+                    continue;
+                };
+                if track.kind != TrackKind::Audio {
+                    continue;
+                }
+                if !track.items.is_empty() && !track_is_empty_boundary(track) {
+                    continue;
+                }
+                if !cluster.contains(&track_index) {
+                    cluster.push(track_index);
+                }
+            }
+            cluster.sort_unstable();
+        }
+
         // Audio targets: reuse existing audio tracks from the cluster, then create
         // new tracks directly below the destination until every clip has a slot.
         let needed = synced_inputs.audio.len();
@@ -1739,7 +1763,6 @@ impl Stack {
             column.push(video_placement);
         }
         column.sort_by_key(|(track_index, _)| *track_index);
-        let column_track_indices: Vec<usize> = column.iter().map(|(track_index, _)| *track_index).collect();
 
         let mut full_column = vec![(dest_track_index, primary_item)];
         full_column.extend(column);
@@ -1754,59 +1777,45 @@ impl Stack {
             full_column = dest_items;
         }
 
-        let mut primary_result = None;
+        let mut insert_updates: Vec<(usize, TrackInsertResult)> = Vec::new();
         for (track_index, item) in full_column {
-            let result = if track_index == dest_track_index {
-                if let Some(dest_index) = dest_index {
-                    self.children[track_index]
-                        .insert_at_index(dest_index, item, overlap_policy)
-                } else {
-                    self.children[track_index].insert_at_time(
-                        dest_time,
-                        item,
-                        overlap_policy,
-                        insert_policy,
-                    )
-                }
-            } else {
-                let sync_track_overlap_policy = if matches!(item, Item::Gap(_))
-                    && overlap_policy == OverlapPolicy::Override
-                    && start >= self.children[track_index].total_duration() - EPS
-                {
-                    OverlapPolicy::Push
-                } else {
-                    overlap_policy
-                };
-                self.children[track_index].insert_at_time(
-                    start,
-                    item,
-                    sync_track_overlap_policy,
-                    InsertPolicy::SplitAndInsert,
-                )
-            };
+            let result = self.children[track_index].insert_at_time(
+                start,
+                item,
+                overlap_policy,
+                InsertPolicy::SplitAndInsert,
+            );
             if !result.success {
                 *self = backup;
                 return None;
             }
-            if track_index == dest_track_index {
-                primary_result = Some(result);
-            }
+            insert_updates.push((track_index, result));
         }
 
-        let Some(primary_result) = primary_result else {
-            *self = backup;
-            return None;
-        };
-        if !self.propagate_track_insert_to_cluster(
-            dest_track_index,
+        let update_refs: Vec<_> = insert_updates
+            .iter()
+            .map(|(track_index, result)| (*track_index, result))
+            .collect();
+        if !self.propagate_insert_to_cluster(
             start,
             modified_duration,
             overlap_policy,
-            &primary_result,
+            &update_refs,
             &cluster,
             sync_clips_id,
-            &column_track_indices,
         ) {
+            *self = backup;
+            return None;
+        }
+        if overlap_policy == OverlapPolicy::Push
+            && !self.propagate_push_to_cluster(
+                start,
+                start + modified_duration,
+                modified_duration,
+                &update_refs,
+                &cluster,
+            )
+        {
             *self = backup;
             return None;
         }
@@ -3560,7 +3569,7 @@ fn item_tellers_group_id(item: &Item) -> Option<i64> {
     }
 }
 
-fn set_resolve_sync_clips_id(metadata: &mut serde_json::Value, sync_clips_id: i64) {
+pub(super) fn set_resolve_sync_clips_id(metadata: &mut serde_json::Value, sync_clips_id: i64) {
     if metadata.as_object().is_none() {
         *metadata = serde_json::Value::Object(serde_json::Map::new());
     }

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -3,6 +3,7 @@ use crate::{
 };
 use std::collections::{HashMap, HashSet};
 
+mod stack_insert_propagate;
 mod stack_item_delete;
 mod stack_item_get;
 mod stack_item_insert;
@@ -294,19 +295,46 @@ impl Stack {
         overlap_policy: OverlapPolicy,
         insert_policy: InsertPolicy,
     ) {
-        self.prepare_sync_splits_for_insert(
-            track_index,
+        if overlap_policy == OverlapPolicy::Push {
+            let _ = self.children[track_index].insert_at_time(
+                insert_time,
+                item,
+                overlap_policy,
+                insert_policy,
+            );
+            return;
+        }
+
+        let prefer_cluster_with_video = self.children.get(track_index).is_some_and(|track| {
+            track.kind == TrackKind::Video
+        });
+        let cluster = self.preferred_cluster_indices(track_index, prefer_cluster_with_video);
+        let start = insertion_start_or_end_for_policy(
+            &self.children[track_index],
             insert_time,
-            &item,
             insert_policy,
-            overlap_policy,
-        );
-        self.children[track_index].insert_at_time(
+        )
+        .unwrap_or(insert_time);
+        let duration = item.duration().max(0.0);
+
+        let primary_result = self.children[track_index].insert_at_time(
             insert_time,
             item,
             overlap_policy,
             insert_policy,
         );
+        if primary_result.success {
+            let _ = self.propagate_track_insert_to_cluster(
+                track_index,
+                start,
+                duration,
+                overlap_policy,
+                &primary_result,
+                &cluster,
+                None,
+                &[],
+            );
+        }
     }
 
     fn find_or_create_audio_track(
@@ -1505,6 +1533,8 @@ impl Stack {
         insert_policy: InsertPolicy,
         synced_audio_clips: Option<Vec<Item>>,
         synced_video_clip: Option<Item>,
+        preferred_video_track_id: Option<&str>,
+        preferred_audio_track_indices: Option<&[usize]>,
     ) -> Option<InsertItemAtTimeResult> {
         let mut primary_item = item;
         primary_item.clamp_to_active_available_range();
@@ -1516,7 +1546,7 @@ impl Stack {
             return None;
         }
         if synced_inputs.video.is_some()
-            && self.children.get(dest_track_index)?.kind != TrackKind::Audio
+            && self.children.get(dest_track_index)?.kind == TrackKind::Video
         {
             return None;
         }
@@ -1546,54 +1576,49 @@ impl Stack {
         let sync_clips_id = has_synced_clips.then(|| self.next_sync_clips_id());
         let mut created_track_indices = Vec::new();
 
-        // The cluster is the sync group the destination track belongs to — the
-        // same grouping `sync_track_info` reports (tracks already synced with
-        // the destination). Staying within this group means unrelated groups
-        // and empty tracks are never disturbed.
+        // Pick the best sync cluster for the destination: prefer video when inserting
+        // on a video track or supplying a synced video clip, otherwise prefer most tracks.
+        let prefer_cluster_with_video = self.children.get(dest_track_index).is_some_and(|track| {
+            track.kind == TrackKind::Video
+        }) || synced_inputs.video.is_some();
         let mut dest_track_index = dest_track_index;
-        let mut cluster = self.boundary_group_indices(dest_track_index);
+        let mut cluster = self.resolve_insert_cluster(
+            dest_track_index,
+            prefer_cluster_with_video,
+            if synced_inputs.video.is_some() {
+                preferred_video_track_id
+            } else {
+                None
+            },
+        );
 
-        // Audio targets, in order: the group's existing audio tracks, then free
-        // audio tracks just below the video (lower indices render below it in
-        // the timeline), then newly created tracks below the video. We never
-        // cross a video boundary or overwrite an occupied track.
+        // Audio targets: reuse existing audio tracks from the cluster, then create
+        // new tracks directly below the destination until every clip has a slot.
         let needed = synced_inputs.audio.len();
-        let end_time = start + column_span;
         let mut audio_slots: Vec<usize> = cluster
             .iter()
             .copied()
             .filter(|&i| i != dest_track_index && self.children[i].kind == TrackKind::Audio)
             .collect();
 
-        let mut scan = dest_track_index;
-        while audio_slots.len() < needed && scan > 0 {
-            scan -= 1;
-            match self.children[scan].kind {
-                // Don't cross into another video's cluster.
-                TrackKind::Video => break,
-                TrackKind::Other => continue,
-                TrackKind::Audio => {
-                    if audio_slots.contains(&scan) {
-                        continue;
-                    }
-                    // Reuse only tracks that are free over the insert range, but
-                    // skip occupied ones and keep scanning — there may be free
-                    // space further below to reuse before creating a new track.
-                    if range_has_blocking_clip(
-                        &self.children[scan],
-                        start,
-                        end_time,
-                        sync_clips_id,
-                    ) {
-                        continue;
-                    }
-                    audio_slots.push(scan);
+        if let Some(preferred_indices) = preferred_audio_track_indices {
+            for &track_index in preferred_indices {
+                if audio_slots.len() >= needed {
+                    break;
                 }
+                if track_index == dest_track_index {
+                    continue;
+                }
+                let Some(track) = self.children.get(track_index) else {
+                    continue;
+                };
+                if track.kind != TrackKind::Audio || audio_slots.contains(&track_index) {
+                    continue;
+                }
+                audio_slots.push(track_index);
             }
         }
 
-        // Create any remaining audio tracks directly below the video. Inserting
-        // below the destination shifts it (and the group) up by one each time.
         while audio_slots.len() < needed {
             let insert_at = dest_track_index;
             let track = self.new_numbered_track(TrackKind::Audio);
@@ -1623,16 +1648,33 @@ impl Stack {
         if let Some(video_item) = synced_inputs.video {
             let video_span = Self::sanitized_clip_duration(&video_item).unwrap_or(column_span);
             let track_count_before = self.children.len();
-            let Some(video_track_index) = self.find_or_create_video_track_for_audio(
-                dest_track_index,
-                start,
-                video_span,
-                &mut created_track_indices,
-                sync_clips_id,
-                true,
-                overlap_policy,
-                insert_policy,
-            ) else {
+            let video_track_index = preferred_video_track_id
+                .and_then(|track_id| self.get_track_by_id(track_id))
+                .and_then(|(track_index, _)| {
+                    self.try_reuse_video_track_for_audio_move(
+                        track_index,
+                        dest_track_index,
+                        start,
+                        start + video_span,
+                        sync_clips_id,
+                        true,
+                        overlap_policy,
+                        insert_policy,
+                    )
+                })
+                .or_else(|| {
+                    self.find_or_create_video_track_for_audio(
+                        dest_track_index,
+                        start,
+                        video_span,
+                        &mut created_track_indices,
+                        sync_clips_id,
+                        true,
+                        overlap_policy,
+                        insert_policy,
+                    )
+                });
+            let Some(video_track_index) = video_track_index else {
                 *self = backup;
                 return None;
             };
@@ -1672,10 +1714,11 @@ impl Stack {
                 (item, id)
             }
         };
-        let mut column = vec![(dest_track_index, primary_item)];
+        let mut column = Vec::new();
 
-        // Assign clips to the audio tracks nearest the video first (highest
-        // index just below it), so the first clip sits directly under the video.
+        // Assign the first synced audio to the audio track immediately below the
+        // destination (largest index still less than `dest_track_index` in Resolve
+        // layout), then the next-nearest, and so on.
         audio_slots.sort_by(|a, b| b.cmp(a));
 
         // Audio clips onto the nearest cluster audio tracks.
@@ -1695,69 +1738,77 @@ impl Stack {
         if let Some(video_placement) = column_video {
             column.push(video_placement);
         }
-
-        // Pad every remaining cluster track with a gap spacer of the same
-        // duration so the whole cluster splits at the insertion point.
-        for &track_index in &cluster {
-            if column.iter().any(|(t, _)| *t == track_index) {
-                continue;
-            }
-            let mut gap = Item::Gap(Gap::make_gap(modified_duration));
-            Self::ensure_unique_item_id(&mut gap, &mut used_ids);
-            column.push((track_index, gap));
-        }
         column.sort_by_key(|(track_index, _)| *track_index);
+        let column_track_indices: Vec<usize> = column.iter().map(|(track_index, _)| *track_index).collect();
 
-        if overlap_policy == OverlapPolicy::Override
-            && matches!(insert_policy, InsertPolicy::SplitAndInsert)
-            && !self.apply_sync_splits_for_column_insert(
-                start,
-                modified_duration,
-                insert_policy,
-                overlap_policy,
-                SyncSplitIdPolicy::AssignNewIdToRight,
-                Some(&cluster),
-            )
-        {
-            *self = backup;
-            return None;
+        let mut full_column = vec![(dest_track_index, primary_item)];
+        full_column.extend(column);
+        if overlap_policy == OverlapPolicy::Push {
+            full_column.sort_by_key(|(track_index, _)| *track_index);
+        } else {
+            let (mut dest_items, mut partners): (Vec<_>, Vec<_>) = full_column
+                .into_iter()
+                .partition(|(track_index, _)| *track_index == dest_track_index);
+            partners.sort_by_key(|(track_index, _)| *track_index);
+            dest_items.extend(partners);
+            full_column = dest_items;
         }
 
-        // Insert the whole column. The primary lands at the requested position
-        // with the caller's insert policy; every other track receives its item
-        // at the same resolved start with the same overlap policy, splitting at
-        // that exact time, so all tracks are edited identically.
-        for (track_index, item) in column {
-            if track_index == dest_track_index {
+        let mut primary_result = None;
+        for (track_index, item) in full_column {
+            let result = if track_index == dest_track_index {
                 if let Some(dest_index) = dest_index {
-                    self.children[track_index].insert_at_index(dest_index, item, overlap_policy);
+                    self.children[track_index]
+                        .insert_at_index(dest_index, item, overlap_policy)
                 } else {
                     self.children[track_index].insert_at_time(
                         dest_time,
                         item,
                         overlap_policy,
                         insert_policy,
-                    );
+                    )
                 }
-                continue;
-            }
-
-            // A gap spacer that lands at or past the end of an Override track has
-            // nothing to overwrite, so push it to extend the track instead.
-            let sync_track_overlap_policy = if matches!(item, Item::Gap(_))
-                && overlap_policy == OverlapPolicy::Override
-                && start >= self.children[track_index].total_duration() - EPS
-            {
-                OverlapPolicy::Push
             } else {
-                overlap_policy
+                let sync_track_overlap_policy = if matches!(item, Item::Gap(_))
+                    && overlap_policy == OverlapPolicy::Override
+                    && start >= self.children[track_index].total_duration() - EPS
+                {
+                    OverlapPolicy::Push
+                } else {
+                    overlap_policy
+                };
+                self.children[track_index].insert_at_time(
+                    start,
+                    item,
+                    sync_track_overlap_policy,
+                    InsertPolicy::SplitAndInsert,
+                )
             };
-            self.children[track_index].insert_at_time(
-                start,
-                item,
-                sync_track_overlap_policy,
-                InsertPolicy::SplitAndInsert,
-            );
+            if !result.success {
+                *self = backup;
+                return None;
+            }
+            if track_index == dest_track_index {
+                primary_result = Some(result);
+            }
+        }
+
+        let Some(primary_result) = primary_result else {
+            *self = backup;
+            return None;
+        };
+        if !self.propagate_track_insert_to_cluster(
+            dest_track_index,
+            start,
+            modified_duration,
+            overlap_policy,
+            &primary_result,
+            &cluster,
+            sync_clips_id,
+            &column_track_indices,
+        ) {
+            *self = backup;
+            return None;
         }
 
         self.sanitize_preserving_all_gap_tracks();
@@ -2717,6 +2768,7 @@ impl Stack {
         }
 
         let mut linked_audio_items = Vec::new();
+        let mut preferred_audio_track_indices = Vec::new();
         let mut linked_video_item = None;
         let dest_is_audio = self.children.get(dest_track_index).is_some_and(|track| {
             track.kind == TrackKind::Audio
@@ -2746,6 +2798,7 @@ impl Stack {
             if is_same_time_audio_clip {
                 if let Item::Clip(clip) = item {
                     linked_audio_items.push(Item::Clip(clip));
+                    preferred_audio_track_indices.push(source_track_index);
                 }
             } else if dest_is_audio
                 && matches!(source_track_kind, Some(TrackKind::Video))
@@ -2791,14 +2844,18 @@ impl Stack {
                 insert_policy,
             );
         } else {
-            let Some(insert_result) = self.insert_item_at_time(
+            let Some(insert_result) = self.insert_synced_item_at_time(
                 dest_track_index,
                 dest_time,
+                None,
                 item_to_move,
                 overlap_policy,
                 insert_policy,
                 (!linked_audio_items.is_empty()).then_some(linked_audio_items),
                 None,
+                preferred_cluster_video_id.as_deref(),
+                (!preferred_audio_track_indices.is_empty())
+                    .then_some(preferred_audio_track_indices.as_slice()),
             ) else {
                 *self = backup;
                 return false;
@@ -2890,13 +2947,17 @@ impl Stack {
         let primary_item = selected.item.clone();
 
         let mut synced_audio = Vec::new();
+        let mut preferred_audio_track_indices = Vec::new();
         let mut synced_video = None;
         for item in &items_to_move {
             if item.is_selected {
                 continue;
             }
             match item.track_kind {
-                TrackKind::Audio => synced_audio.push(item.item.clone()),
+                TrackKind::Audio => {
+                    synced_audio.push(item.item.clone());
+                    preferred_audio_track_indices.push(item.track_index);
+                }
                 TrackKind::Video => {
                     if synced_video.is_some() {
                         return false;
@@ -2918,14 +2979,18 @@ impl Stack {
 
         let synced_audio_clips = (!synced_audio.is_empty()).then_some(synced_audio);
         if self
-            .insert_item_at_time(
+            .insert_synced_item_at_time(
                 dest_track_index,
                 dest_time,
+                None,
                 primary_item,
                 overlap_policy,
                 insert_policy,
                 synced_audio_clips,
                 synced_video,
+                None,
+                (!preferred_audio_track_indices.is_empty())
+                    .then_some(preferred_audio_track_indices.as_slice()),
             )
             .is_some()
         {
@@ -3203,14 +3268,17 @@ impl Stack {
                     SyncedMovePlacement::Time {
                         dest_time,
                         insert_policy,
-                    } => self.children[track_index].insert_at_time(
-                        dest_time,
-                        item,
-                        overlap_policy,
-                        insert_policy,
-                    ),
+                    } => {
+                        let _ = self.children[track_index].insert_at_time(
+                            dest_time,
+                            item,
+                            overlap_policy,
+                            insert_policy,
+                        );
+                    }
                     SyncedMovePlacement::Index { dest_index } => {
-                        self.children[track_index].insert_at_index(dest_index, item, overlap_policy)
+                        let _ = self.children[track_index]
+                            .insert_at_index(dest_index, item, overlap_policy);
                     }
                 }
             } else {
@@ -3471,35 +3539,25 @@ fn insertion_start_or_end_for_policy(
 }
 
 fn resolve_sync_clips_id(metadata: &serde_json::Value) -> Option<i64> {
-    resolve_metadata_i64(metadata, "Link Group ID")
+    Clip::resolve_otio_i64(metadata, "Link Group ID")
 }
 
 fn resolve_tellers_group_id(metadata: &serde_json::Value) -> Option<i64> {
-    resolve_metadata_i64(metadata, "Tellers Group ID")
+    Clip::resolve_otio_i64(metadata, "Tellers Group ID")
 }
 
 fn item_link_group_id(item: &Item) -> Option<i64> {
     match item {
-        Item::Clip(clip) => resolve_sync_clips_id(&clip.metadata),
+        Item::Clip(clip) => clip.sync_clips_id(),
         Item::Gap(_) => None,
     }
 }
 
 fn item_tellers_group_id(item: &Item) -> Option<i64> {
     match item {
-        Item::Clip(clip) => resolve_tellers_group_id(&clip.metadata),
+        Item::Clip(clip) => Clip::resolve_otio_i64(&clip.metadata, "Tellers Group ID"),
         Item::Gap(_) => None,
     }
-}
-
-fn resolve_metadata_i64(metadata: &serde_json::Value, key: &str) -> Option<i64> {
-    let raw = metadata
-        .get("Resolve_OTIO")
-        .or_else(|| metadata.get("resolve"))
-        .and_then(|v| v.get(key))?;
-    raw.as_i64()
-        .or_else(|| raw.as_u64().and_then(|value| i64::try_from(value).ok()))
-        .or_else(|| raw.as_str().and_then(|value| value.parse::<i64>().ok()))
 }
 
 fn set_resolve_sync_clips_id(metadata: &mut serde_json::Value, sync_clips_id: i64) {

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -1197,6 +1197,79 @@ impl Stack {
         inputs
     }
 
+    fn destination_move_audio_candidates(
+        &self,
+        dest_track_index: usize,
+        used_audio_indices: &[usize],
+    ) -> Vec<usize> {
+        let Some(dest_track) = self.children.get(dest_track_index) else {
+            return Vec::new();
+        };
+        match dest_track.kind {
+            TrackKind::Video => {
+                let mut candidates = Vec::new();
+                let mut above = dest_track_index;
+                while above > 0 && self.children[above - 1].kind == TrackKind::Audio {
+                    above -= 1;
+                    if !used_audio_indices.contains(&above) {
+                        candidates.push(above);
+                    }
+                }
+                let mut below = dest_track_index + 1;
+                while below < self.children.len() && self.children[below].kind == TrackKind::Audio {
+                    if !used_audio_indices.contains(&below) {
+                        candidates.push(below);
+                    }
+                    below += 1;
+                }
+                candidates
+            }
+            TrackKind::Audio => self
+                .boundary_group_indices(dest_track_index)
+                .into_iter()
+                .filter(|&track_index| {
+                    track_index != dest_track_index
+                        && self.children.get(track_index).is_some_and(|track| {
+                            track.kind == TrackKind::Audio
+                                && !used_audio_indices.contains(&track_index)
+                        })
+                })
+                .collect(),
+            TrackKind::Other => Vec::new(),
+        }
+    }
+
+    fn find_usable_destination_move_audio_track(
+        &self,
+        dest_track_index: usize,
+        dest_time: Seconds,
+        duration: Seconds,
+        used_audio_indices: &[usize],
+        exclude_track_indices: &HashSet<usize>,
+    ) -> Option<usize> {
+        let end_time = dest_time + duration;
+        self.destination_move_audio_candidates(dest_track_index, used_audio_indices)
+            .into_iter()
+            .filter(|track_index| !exclude_track_indices.contains(track_index))
+            .find(|&track_index| {
+                self.children.get(track_index).is_some_and(|track| {
+                    track_is_empty_boundary(track)
+                        || range_is_gap_backed(track, dest_time, end_time)
+                        || self.track_matches_primary_sync_boundary(dest_track_index, track_index)
+                })
+            })
+    }
+
+    fn has_non_source_destination_audio_tracks(
+        &self,
+        dest_track_index: usize,
+        exclude_track_indices: &HashSet<usize>,
+    ) -> bool {
+        self.destination_move_audio_candidates(dest_track_index, &[])
+            .iter()
+            .any(|track_index| !exclude_track_indices.contains(track_index))
+    }
+
     fn preferred_move_audio_track_usable(
         &self,
         dest_track_index: usize,
@@ -1204,6 +1277,7 @@ impl Stack {
         dest_time: Seconds,
         duration: Seconds,
         used_audio_indices: &[usize],
+        exclude_track_indices: &HashSet<usize>,
     ) -> bool {
         if candidate_index == dest_track_index {
             return false;
@@ -1215,6 +1289,15 @@ impl Stack {
             return false;
         }
         let end_time = dest_time + duration;
+        let dest_cluster: HashSet<usize> = self
+            .boundary_group_indices(dest_track_index)
+            .into_iter()
+            .collect();
+        if !dest_cluster.contains(&candidate_index)
+            && self.has_non_source_destination_audio_tracks(dest_track_index, exclude_track_indices)
+        {
+            return false;
+        }
         if track_is_empty_boundary(track) {
             return true;
         }
@@ -1222,6 +1305,46 @@ impl Stack {
             return true;
         }
         self.track_matches_primary_sync_boundary(dest_track_index, candidate_index)
+    }
+
+    fn find_or_create_destination_move_audio_track(
+        &mut self,
+        dest_track_index: usize,
+        dest_time: Seconds,
+        duration: Seconds,
+        created_track_indices: &mut Vec<usize>,
+        used_audio_indices: &[usize],
+        exclude_track_indices: &HashSet<usize>,
+    ) -> Option<usize> {
+        if let Some(track_index) = self.find_usable_destination_move_audio_track(
+            dest_track_index,
+            dest_time,
+            duration,
+            used_audio_indices,
+            exclude_track_indices,
+        ) {
+            return Some(track_index);
+        }
+
+        let insert_at = match self.children.get(dest_track_index)?.kind {
+            TrackKind::Video => {
+                let mut above = dest_track_index;
+                while above > 0 && self.children[above - 1].kind == TrackKind::Audio {
+                    above -= 1;
+                }
+                if above < dest_track_index {
+                    dest_track_index
+                } else {
+                    dest_track_index + 1
+                }
+            }
+            TrackKind::Audio => dest_track_index + 1,
+            TrackKind::Other => return None,
+        };
+        self.children
+            .insert(insert_at, self.new_numbered_track(TrackKind::Audio));
+        created_track_indices.push(insert_at);
+        Some(insert_at)
     }
 
     fn assign_move_audio_slots(
@@ -1232,6 +1355,7 @@ impl Stack {
         start: Seconds,
         audio_durations: &[Seconds],
         preferred_indices: &[usize],
+        exclude_track_indices: &HashSet<usize>,
     ) -> Option<Vec<usize>> {
         let needed = audio_durations.len();
         let mut audio_slots = Vec::with_capacity(needed);
@@ -1249,16 +1373,26 @@ impl Stack {
                         start,
                         duration,
                         &used_audio_indices,
+                        exclude_track_indices,
                     )
                 })
                 .or_else(|| {
-                    self.find_or_create_move_audio_track(
+                    self.find_usable_destination_move_audio_track(
+                        *dest_track_index,
+                        start,
+                        duration,
+                        &used_audio_indices,
+                        exclude_track_indices,
+                    )
+                })
+                .or_else(|| {
+                    self.find_or_create_destination_move_audio_track(
                         *dest_track_index,
                         start,
                         duration,
                         created_track_indices,
                         &used_audio_indices,
-                        &used_audio_boundary_indices,
+                        exclude_track_indices,
                     )
                 })?;
 
@@ -1621,6 +1755,7 @@ impl Stack {
         synced_video_clip: Option<Item>,
         preferred_video_track_id: Option<&str>,
         preferred_audio_track_indices: Option<&[usize]>,
+        move_source_track_indices: Option<&[usize]>,
     ) -> Option<InsertItemAtTimeResult> {
         let mut primary_item = item;
         primary_item.clamp_to_active_available_range();
@@ -1682,6 +1817,11 @@ impl Stack {
         // tracks. Empty preferred tracks (no clips, or gaps only) are part of the
         // destination working cluster so insert propagation applies there too.
         if let Some(preferred_indices) = preferred_audio_track_indices {
+            for track_index in self.destination_move_audio_candidates(dest_track_index, &[]) {
+                if !cluster.contains(&track_index) {
+                    cluster.push(track_index);
+                }
+            }
             for &track_index in preferred_indices {
                 if track_index == dest_track_index {
                     continue;
@@ -1713,6 +1853,9 @@ impl Stack {
         let mut audio_slots: Vec<usize> = if let Some(preferred_indices) =
             preferred_audio_track_indices
         {
+            let exclude_track_indices: HashSet<usize> = move_source_track_indices
+                .map(|indices| indices.iter().copied().collect())
+                .unwrap_or_default();
             self.assign_move_audio_slots(
                 &mut dest_track_index,
                 &mut cluster,
@@ -1720,6 +1863,7 @@ impl Stack {
                 start,
                 &audio_durations,
                 preferred_indices,
+                &exclude_track_indices,
             )?
         } else {
             let mut slots: Vec<usize> = cluster
@@ -2975,6 +3119,7 @@ impl Stack {
                 preferred_cluster_video_id.as_deref(),
                 (!preferred_audio_track_indices.is_empty())
                     .then_some(preferred_audio_track_indices.as_slice()),
+                None::<&[usize]>,
             ) else {
                 *self = backup;
                 return false;
@@ -3068,15 +3213,17 @@ impl Stack {
         let mut synced_audio = Vec::new();
         let mut preferred_audio_track_indices = Vec::new();
         let mut synced_video = None;
+        let mut audio_partners: Vec<_> = items_to_move
+            .iter()
+            .filter(|item| !item.is_selected && item.track_kind == TrackKind::Audio)
+            .collect();
+        audio_partners.sort_by_key(|item| item.track_index);
         for item in &items_to_move {
             if item.is_selected {
                 continue;
             }
             match item.track_kind {
-                TrackKind::Audio => {
-                    synced_audio.push(item.item.clone());
-                    preferred_audio_track_indices.push(item.track_index);
-                }
+                TrackKind::Audio => continue,
                 TrackKind::Video => {
                     if synced_video.is_some() {
                         return false;
@@ -3086,6 +3233,12 @@ impl Stack {
                 TrackKind::Other => return false,
             }
         }
+        for item in audio_partners {
+            synced_audio.push(item.item.clone());
+            preferred_audio_track_indices.push(item.track_index);
+        }
+        let move_source_track_indices: Vec<usize> =
+            items_to_move.iter().map(|item| item.track_index).collect();
 
         let Some(targets) = self.delete_item_targets(&item_id) else {
             return false;
@@ -3110,6 +3263,7 @@ impl Stack {
                 None,
                 (!preferred_audio_track_indices.is_empty())
                     .then_some(preferred_audio_track_indices.as_slice()),
+                Some(move_source_track_indices.as_slice()),
             )
             .is_some()
         {

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -1197,6 +1197,92 @@ impl Stack {
         inputs
     }
 
+    fn preferred_move_audio_track_usable(
+        &self,
+        dest_track_index: usize,
+        candidate_index: usize,
+        dest_time: Seconds,
+        duration: Seconds,
+        used_audio_indices: &[usize],
+    ) -> bool {
+        if candidate_index == dest_track_index {
+            return false;
+        }
+        let Some(track) = self.children.get(candidate_index) else {
+            return false;
+        };
+        if track.kind != TrackKind::Audio || used_audio_indices.contains(&candidate_index) {
+            return false;
+        }
+        let end_time = dest_time + duration;
+        if track_is_empty_boundary(track) {
+            return true;
+        }
+        if range_is_gap_backed(track, dest_time, end_time) {
+            return true;
+        }
+        self.track_matches_primary_sync_boundary(dest_track_index, candidate_index)
+    }
+
+    fn assign_move_audio_slots(
+        &mut self,
+        dest_track_index: &mut usize,
+        cluster: &mut Vec<usize>,
+        created_track_indices: &mut Vec<usize>,
+        start: Seconds,
+        audio_durations: &[Seconds],
+        preferred_indices: &[usize],
+    ) -> Option<Vec<usize>> {
+        let needed = audio_durations.len();
+        let mut audio_slots = Vec::with_capacity(needed);
+        let mut used_audio_indices = Vec::new();
+        let mut used_audio_boundary_indices = Vec::new();
+
+        for (audio_index, &duration) in audio_durations.iter().enumerate() {
+            let track_count_before = self.children.len();
+            let preferred = preferred_indices.get(audio_index).copied();
+            let track_index = preferred
+                .filter(|&preferred_index| {
+                    self.preferred_move_audio_track_usable(
+                        *dest_track_index,
+                        preferred_index,
+                        start,
+                        duration,
+                        &used_audio_indices,
+                    )
+                })
+                .or_else(|| {
+                    self.find_or_create_move_audio_track(
+                        *dest_track_index,
+                        start,
+                        duration,
+                        created_track_indices,
+                        &used_audio_indices,
+                        &used_audio_boundary_indices,
+                    )
+                })?;
+
+            if self.children.len() > track_count_before {
+                Self::shift_insert_track_indices_after_create(
+                    track_index,
+                    dest_track_index,
+                    cluster,
+                    &mut audio_slots,
+                    created_track_indices,
+                );
+            }
+            let reused_empty_boundary = self.children.len() == track_count_before
+                && track_is_empty_boundary(&self.children[track_index]);
+            audio_slots.push(track_index);
+            used_audio_indices.push(track_index);
+            if reused_empty_boundary {
+                used_audio_boundary_indices.push(track_index);
+            }
+        }
+
+        Some(audio_slots)
+    }
+
     fn shift_insert_track_indices_after_create(
         inserted_at: usize,
         dest_track_index: &mut usize,
@@ -1619,29 +1705,53 @@ impl Stack {
         // Audio targets: reuse existing audio tracks from the cluster, then create
         // new tracks directly below the destination until every clip has a slot.
         let needed = synced_inputs.audio.len();
-        let mut audio_slots: Vec<usize> = cluster
+        let audio_durations: Vec<Seconds> = synced_inputs
+            .audio
             .iter()
-            .copied()
-            .filter(|&i| i != dest_track_index && self.children[i].kind == TrackKind::Audio)
+            .map(|item| Self::sanitized_clip_duration(item).unwrap_or(modified_duration))
             .collect();
-
-        if let Some(preferred_indices) = preferred_audio_track_indices {
-            for &track_index in preferred_indices {
-                if audio_slots.len() >= needed {
-                    break;
+        let mut audio_slots: Vec<usize> = if let Some(preferred_indices) =
+            preferred_audio_track_indices
+        {
+            self.assign_move_audio_slots(
+                &mut dest_track_index,
+                &mut cluster,
+                &mut created_track_indices,
+                start,
+                &audio_durations,
+                preferred_indices,
+            )?
+        } else {
+            let mut slots: Vec<usize> = cluster
+                .iter()
+                .copied()
+                .filter(|&i| i != dest_track_index && self.children[i].kind == TrackKind::Audio)
+                .collect();
+            while slots.len() < needed {
+                let insert_at = dest_track_index;
+                let track = self.new_numbered_track(TrackKind::Audio);
+                self.children.insert(insert_at, track);
+                for index in created_track_indices.iter_mut() {
+                    if *index >= insert_at {
+                        *index += 1;
+                    }
                 }
-                if track_index == dest_track_index {
-                    continue;
+                created_track_indices.push(insert_at);
+                dest_track_index += 1;
+                for index in cluster.iter_mut() {
+                    if *index >= insert_at {
+                        *index += 1;
+                    }
                 }
-                let Some(track) = self.children.get(track_index) else {
-                    continue;
-                };
-                if track.kind != TrackKind::Audio || audio_slots.contains(&track_index) {
-                    continue;
+                for index in slots.iter_mut() {
+                    if *index >= insert_at {
+                        *index += 1;
+                    }
                 }
-                audio_slots.push(track_index);
+                slots.push(insert_at);
             }
-        }
+            slots
+        };
 
         while audio_slots.len() < needed {
             let insert_at = dest_track_index;

--- a/tellers-timeline-core/src/stack_methods/stack_insert_propagate.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_insert_propagate.rs
@@ -461,7 +461,14 @@ impl Stack {
             };
 
             let right_sync_clips_id = match (insert_sync_clips_id, overlap_policy) {
-                (Some(id), OverlapPolicy::Override) => id,
+                (Some(insert_id), OverlapPolicy::Override) => {
+                    let right_id = sync_id + 1;
+                    if right_id == insert_id {
+                        insert_id + 1
+                    } else {
+                        right_id
+                    }
+                }
                 (Some(_), OverlapPolicy::Push) => self.next_sync_clips_id(),
                 (None, OverlapPolicy::Override) => self.next_sync_clips_id(),
                 (None, OverlapPolicy::Push) => sync_id,

--- a/tellers-timeline-core/src/stack_methods/stack_insert_propagate.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_insert_propagate.rs
@@ -1,0 +1,604 @@
+use crate::{
+    Gap, IdMetadataExt, InsertPolicy, Item, OverlapPolicy, Seconds, SplitClipInfo, Stack, TrackInsertResult,
+};
+use std::collections::{HashMap, HashSet};
+
+use super::{resolve_sync_clips_id, EPS};
+
+fn is_split_fragment(clip_id: &str, splits: &[SplitClipInfo]) -> bool {
+    splits.iter().any(|split| {
+        split.left_clip_id.as_deref() == Some(clip_id)
+            || split.right_clip_id.as_deref() == Some(clip_id)
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SplitOutcome {
+    BothSides,
+    LeftOnly,
+    RightOnly,
+}
+
+impl Stack {
+    fn pick_best_sync_cluster(
+        &self,
+        groups: Vec<super::SyncTrackInfo>,
+        prefer_cluster_with_video: bool,
+    ) -> Option<Vec<usize>> {
+        if groups.is_empty() {
+            return None;
+        }
+        groups
+            .into_iter()
+            .max_by(|left, right| {
+                if prefer_cluster_with_video {
+                    use crate::TrackKind;
+                    let left_has_video = left.track_indices.iter().any(|&i| {
+                        self.children
+                            .get(i)
+                            .is_some_and(|track| track.kind == TrackKind::Video)
+                    });
+                    let right_has_video = right.track_indices.iter().any(|&i| {
+                        self.children
+                            .get(i)
+                            .is_some_and(|track| track.kind == TrackKind::Video)
+                    });
+                    match (left_has_video, right_has_video) {
+                        (true, false) => std::cmp::Ordering::Greater,
+                        (false, true) => std::cmp::Ordering::Less,
+                        _ => left
+                            .track_indices
+                            .len()
+                            .cmp(&right.track_indices.len()),
+                    }
+                } else {
+                    left.track_indices
+                        .len()
+                        .cmp(&right.track_indices.len())
+                }
+            })
+            .map(|group| group.track_indices)
+    }
+
+    /// Among sync clusters containing `track_index`, prefer one with a video track
+    /// when `prefer_cluster_with_video` is true (insert on a video track or using a
+    /// synced video clip), otherwise prefer the cluster with the most tracks.
+    pub(super) fn preferred_cluster_indices(
+        &self,
+        track_index: usize,
+        prefer_cluster_with_video: bool,
+    ) -> Vec<usize> {
+        let groups: Vec<_> = self
+            .sync_track_info()
+            .into_iter()
+            .filter(|group| group.track_indices.contains(&track_index))
+            .collect();
+
+        self.pick_best_sync_cluster(groups, prefer_cluster_with_video)
+            .unwrap_or_else(|| vec![track_index])
+    }
+
+    /// Resolve the working sync cluster for an insert. When a synced video clip is
+    /// used but the destination cluster has no video track, merge in the best cluster
+    /// that contains `preferred_video_track_id`.
+    pub(super) fn resolve_insert_cluster(
+        &self,
+        dest_track_index: usize,
+        prefer_cluster_with_video: bool,
+        preferred_video_track_id: Option<&str>,
+    ) -> Vec<usize> {
+        let mut cluster =
+            self.preferred_cluster_indices(dest_track_index, prefer_cluster_with_video);
+
+        if !prefer_cluster_with_video {
+            return cluster;
+        }
+
+        let cluster_has_video = cluster.iter().any(|&track_index| {
+            self.children
+                .get(track_index)
+                .is_some_and(|track| track.kind == crate::TrackKind::Video)
+        });
+        if cluster_has_video {
+            return cluster;
+        }
+
+        let Some(preferred_video_track_id) = preferred_video_track_id else {
+            return cluster;
+        };
+        let Some((preferred_video_index, preferred_track)) =
+            self.get_track_by_id(preferred_video_track_id)
+        else {
+            return cluster;
+        };
+        if preferred_track.kind != crate::TrackKind::Video {
+            return cluster;
+        }
+
+        let video_groups: Vec<_> = self
+            .sync_track_info()
+            .into_iter()
+            .filter(|group| group.track_indices.contains(&preferred_video_index))
+            .collect();
+
+        if let Some(video_cluster) = self.pick_best_sync_cluster(video_groups, true) {
+            for track_index in video_cluster {
+                if !cluster.contains(&track_index) {
+                    cluster.push(track_index);
+                }
+            }
+        } else if !cluster.contains(&preferred_video_index) {
+            cluster.push(preferred_video_index);
+        }
+
+        cluster.sort_unstable();
+        cluster
+    }
+
+    /// Apply primary-track insert mutations to synced clips on partner tracks in `cluster`.
+    pub(super) fn propagate_track_insert_to_cluster(
+        &mut self,
+        dest_track_index: usize,
+        insert_start: Seconds,
+        insert_duration: Seconds,
+        overlap_policy: OverlapPolicy,
+        track_result: &TrackInsertResult,
+        cluster: &[usize],
+        insert_sync_clips_id: Option<i64>,
+        column_tracks: &[usize],
+    ) -> bool {
+        if insert_duration <= EPS {
+            return true;
+        }
+        let insert_end = insert_start + insert_duration;
+
+        let mut deleted_sync_ids = HashSet::new();
+        for deleted in &track_result.deleted_clips {
+            if is_split_fragment(&deleted.clip_id, &track_result.split_clips) {
+                continue;
+            }
+            if let Some(sync_id) = deleted.sync_clips_id {
+                deleted_sync_ids.insert(sync_id);
+            }
+        }
+        for sync_id in deleted_sync_ids {
+            self.delete_sync_clips(sync_id, true);
+        }
+
+        let split_outcomes = self.classify_split_outcomes(
+            track_result,
+            dest_track_index,
+            insert_start,
+            insert_end,
+        );
+        if overlap_policy != OverlapPolicy::Push {
+            for (split, outcome) in split_outcomes {
+                let Some(sync_clips_id) = split.sync_clips_id else {
+                    continue;
+                };
+                match outcome {
+                    SplitOutcome::BothSides => {
+                        let right_sync_clips_id = match insert_sync_clips_id {
+                            Some(id) => id,
+                            None if overlap_policy == OverlapPolicy::Override => {
+                                self.next_sync_clips_id()
+                            }
+                            None => sync_clips_id,
+                        };
+                        if !self.propagate_full_split_to_sync_group(
+                            sync_clips_id,
+                            split.split_time,
+                            insert_start,
+                            insert_duration,
+                            overlap_policy,
+                            cluster,
+                            dest_track_index,
+                            right_sync_clips_id,
+                        ) {
+                            return false;
+                        }
+                    }
+                    SplitOutcome::LeftOnly | SplitOutcome::RightOnly => {
+                        if !self.propagate_partial_split_to_sync_group(
+                            sync_clips_id,
+                            insert_start,
+                            insert_end,
+                            overlap_policy,
+                            cluster,
+                            dest_track_index,
+                        ) {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+
+        if overlap_policy == OverlapPolicy::Push {
+            return self.propagate_push_insert_to_cluster(
+                dest_track_index,
+                insert_start,
+                insert_duration,
+                cluster,
+                column_tracks,
+            );
+        }
+
+        true
+    }
+
+    fn classify_split_outcomes(
+        &self,
+        track_result: &TrackInsertResult,
+        dest_track_index: usize,
+        insert_start: Seconds,
+        insert_end: Seconds,
+    ) -> Vec<(SplitClipInfo, SplitOutcome)> {
+        let mut by_sync_id: HashMap<i64, SplitClipInfo> = HashMap::new();
+        for split in &track_result.split_clips {
+            let Some(sync_id) = split.sync_clips_id else {
+                continue;
+            };
+            by_sync_id
+                .entry(sync_id)
+                .and_modify(|existing| {
+                    if existing.split_time > split.split_time {
+                        existing.split_time = split.split_time;
+                    }
+                    if existing.old_clip_id.is_empty() {
+                        existing.old_clip_id = split.old_clip_id.clone();
+                    }
+                })
+                .or_insert_with(|| split.clone());
+        }
+
+        by_sync_id
+            .into_values()
+            .filter_map(|split| {
+                let sync_id = split.sync_clips_id?;
+                let mut has_left = false;
+                let mut has_right = false;
+                for (track_index, item_index) in self.synced_clips_targets(sync_id) {
+                    if track_index != dest_track_index {
+                        continue;
+                    }
+                    let start = self.children[track_index].start_time_of_item(item_index);
+                    if start + EPS < insert_start {
+                        has_left = true;
+                    }
+                    if start >= insert_end - EPS {
+                        has_right = true;
+                    }
+                }
+                let outcome = match (has_left, has_right) {
+                    (true, true) => SplitOutcome::BothSides,
+                    (true, false) => SplitOutcome::LeftOnly,
+                    (false, true) => SplitOutcome::RightOnly,
+                    (false, false) => return None,
+                };
+                Some((split, outcome))
+            })
+            .collect()
+    }
+
+    fn propagate_full_split_to_sync_group(
+        &mut self,
+        sync_clips_id: i64,
+        split_time: Seconds,
+        insert_start: Seconds,
+        insert_duration: Seconds,
+        overlap_policy: OverlapPolicy,
+        cluster: &[usize],
+        dest_track_index: usize,
+        right_sync_clips_id: i64,
+    ) -> bool {
+        let partner_tracks: Vec<usize> = cluster
+            .iter()
+            .copied()
+            .filter(|&track_index| track_index != dest_track_index)
+            .collect();
+
+        let mut used_ids = self.collect_timeline_ids();
+
+        for track_index in partner_tracks {
+            let needs_split = self.children.get(track_index).is_some_and(|track| {
+                track
+                    .get_item_at_time(split_time)
+                    .and_then(|item_index| track.items.get(item_index))
+                    .and_then(|item| match item {
+                        Item::Clip(clip) => resolve_sync_clips_id(&clip.metadata),
+                        Item::Gap(_) => None,
+                    })
+                    .is_some_and(|id| id == sync_clips_id)
+            });
+
+            if needs_split {
+                self.children[track_index].split_at_time(split_time);
+            }
+
+            if self.track_has_spacer_at(track_index, insert_start, insert_duration) {
+                continue;
+            }
+
+            let mut gap = Item::Gap(Gap::make_gap(insert_duration));
+            Self::ensure_unique_item_id(&mut gap, &mut used_ids);
+            let gap_result = self.children[track_index].insert_at_time(
+                insert_start,
+                gap,
+                overlap_policy,
+                InsertPolicy::SplitAndInsert,
+            );
+            if !gap_result.success {
+                return false;
+            }
+        }
+
+        let right_start_threshold = split_time + insert_duration - EPS;
+        for (track_index, item_index) in self.synced_clips_targets(sync_clips_id) {
+            let item_start = self.children[track_index].start_time_of_item(item_index);
+            if item_start < right_start_threshold {
+                continue;
+            }
+            let Some(Item::Clip(clip)) = self
+                .children
+                .get_mut(track_index)
+                .and_then(|track| track.items.get_mut(item_index))
+            else {
+                continue;
+            };
+            if resolve_sync_clips_id(&clip.metadata) != Some(sync_clips_id) {
+                continue;
+            }
+            super::set_resolve_sync_clips_id(&mut clip.metadata, right_sync_clips_id);
+        }
+
+        true
+    }
+
+    fn propagate_partial_split_to_sync_group(
+        &mut self,
+        sync_clips_id: i64,
+        insert_start: Seconds,
+        insert_end: Seconds,
+        overlap_policy: OverlapPolicy,
+        cluster: &[usize],
+        dest_track_index: usize,
+    ) -> bool {
+        if overlap_policy == OverlapPolicy::Push {
+            let insert_duration = insert_end - insert_start;
+            if insert_duration <= EPS {
+                return true;
+            }
+            let mut used_ids = self.collect_timeline_ids();
+            for track_index in cluster {
+                if *track_index == dest_track_index {
+                    continue;
+                }
+                let Some(track) = self.children.get(*track_index) else {
+                    continue;
+                };
+                let has_sync_clip_in_range = {
+                    let mut pos = 0.0;
+                    let mut found = false;
+                    for item in &track.items {
+                        let item_start = pos;
+                        let item_end = pos + item.duration().max(0.0);
+                        if item_end > insert_start + EPS && item_start < insert_end - EPS {
+                            if let Item::Clip(clip) = item {
+                                if resolve_sync_clips_id(&clip.metadata) == Some(sync_clips_id) {
+                                    found = true;
+                                    break;
+                                }
+                            }
+                        }
+                        pos = item_end;
+                    }
+                    found
+                };
+                if !has_sync_clip_in_range {
+                    continue;
+                }
+                if self.track_has_spacer_at(*track_index, insert_start, insert_duration) {
+                    continue;
+                }
+                let mut gap = Item::Gap(Gap::make_gap(insert_duration));
+                Self::ensure_unique_item_id(&mut gap, &mut used_ids);
+                let result = self.children[*track_index].insert_at_time(
+                    insert_start,
+                    gap,
+                    OverlapPolicy::Push,
+                    InsertPolicy::SplitAndInsert,
+                );
+                if !result.success {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        for track_index in cluster {
+            if *track_index == dest_track_index {
+                continue;
+            }
+            let Some(track) = self.children.get(*track_index) else {
+                continue;
+            };
+            let has_sync_clip_in_range = {
+                let mut pos = 0.0;
+                let mut found = false;
+                for item in &track.items {
+                    let item_start = pos;
+                    let item_end = pos + item.duration().max(0.0);
+                    if item_end > insert_start + EPS && item_start < insert_end - EPS {
+                        if let Item::Clip(clip) = item {
+                            if resolve_sync_clips_id(&clip.metadata) == Some(sync_clips_id) {
+                                found = true;
+                                break;
+                            }
+                        }
+                    }
+                    pos = item_end;
+                }
+                found
+            };
+            if !has_sync_clip_in_range {
+                continue;
+            }
+            self.children[*track_index].delete_range(insert_start, insert_end, true);
+        }
+        true
+    }
+
+    fn propagate_push_insert_to_cluster(
+        &mut self,
+        dest_track_index: usize,
+        insert_start: Seconds,
+        insert_duration: Seconds,
+        cluster: &[usize],
+        column_tracks: &[usize],
+    ) -> bool {
+        let column_track_set: HashSet<usize> = column_tracks.iter().copied().collect();
+        let push_anchor = insert_start + insert_duration;
+        let dest_right_start = self.children.get(dest_track_index).and_then(|track| {
+            let mut pos = 0.0;
+            let mut min_start: Option<Seconds> = None;
+            for item in &track.items {
+                if pos >= push_anchor - EPS {
+                    if let Item::Clip(clip) = item {
+                        if resolve_sync_clips_id(&clip.metadata).is_some() {
+                            min_start = Some(match min_start {
+                                Some(current) => current.min(pos),
+                                None => pos,
+                            });
+                        }
+                    }
+                }
+                pos += item.duration().max(0.0);
+            }
+            min_start
+        });
+
+        let dest_right_start = dest_right_start.unwrap_or(push_anchor);
+        let mut used_ids = self.collect_timeline_ids();
+        for &track_index in cluster {
+            if track_index == dest_track_index || column_track_set.contains(&track_index) {
+                continue;
+            }
+            let Some(partner_sync_start) =
+                self.first_cluster_sync_clip_start_at_or_after(track_index, insert_start, cluster)
+            else {
+                continue;
+            };
+            let (gap_at, gap_duration) = if partner_sync_start <= insert_start + EPS {
+                (insert_start, dest_right_start - insert_start)
+            } else {
+                (insert_start, dest_right_start - partner_sync_start)
+            };
+            if gap_duration <= EPS {
+                continue;
+            }
+            if partner_sync_start <= insert_start + EPS
+                && self.track_has_spacer_at(track_index, gap_at, gap_duration)
+            {
+                continue;
+            }
+            let mut gap = Item::Gap(Gap::make_gap(gap_duration));
+            Self::ensure_unique_item_id(&mut gap, &mut used_ids);
+            let result = self.children[track_index].insert_at_time(
+                gap_at,
+                gap,
+                OverlapPolicy::Push,
+                InsertPolicy::SplitAndInsert,
+            );
+            if !result.success {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn first_cluster_sync_clip_start_at_or_after(
+        &self,
+        track_index: usize,
+        insert_start: Seconds,
+        cluster: &[usize],
+    ) -> Option<Seconds> {
+        let track = self.children.get(track_index)?;
+        let cluster_sync_ids: HashSet<i64> = cluster
+            .iter()
+            .filter_map(|&index| self.children.get(index))
+            .flat_map(|track| track.items.iter())
+            .filter_map(|item| match item {
+                Item::Clip(clip) => resolve_sync_clips_id(&clip.metadata),
+                Item::Gap(_) => None,
+            })
+            .collect();
+        let mut pos = 0.0;
+        let mut any_sync_start: Option<Seconds> = None;
+        for item in &track.items {
+            if pos + item.duration().max(0.0) > insert_start + EPS {
+                if let Item::Clip(clip) = item {
+                    if let Some(sync_id) = resolve_sync_clips_id(&clip.metadata) {
+                        if cluster_sync_ids.is_empty() || cluster_sync_ids.contains(&sync_id) {
+                            return Some(pos);
+                        }
+                        any_sync_start = Some(any_sync_start.map_or(pos, |current| current.min(pos)));
+                    }
+                }
+            }
+            pos += item.duration().max(0.0);
+        }
+        any_sync_start
+    }
+
+    pub(super) fn track_has_spacer_at(
+        &self,
+        track_index: usize,
+        start: Seconds,
+        duration: Seconds,
+    ) -> bool {
+        let Some(track) = self.children.get(track_index) else {
+            return false;
+        };
+        let Some(item_index) = track.get_item_at_time(start) else {
+            return false;
+        };
+        if (track.start_time_of_item(item_index) - start).abs() > EPS {
+            return false;
+        }
+        (track.items[item_index].duration() - duration).abs() <= EPS
+    }
+
+    /// Sync clips on partner tracks that start at or after `insert_start`.
+    pub(super) fn sync_clips_after_time_in_cluster(
+        &self,
+        insert_start: Seconds,
+        cluster: &[usize],
+        dest_track_index: usize,
+    ) -> Vec<(usize, String, i64)> {
+        let mut clips = Vec::new();
+        for &track_index in cluster {
+            if track_index == dest_track_index {
+                continue;
+            }
+            let Some(track) = self.children.get(track_index) else {
+                continue;
+            };
+            let mut pos = 0.0;
+            for item in &track.items {
+                if pos >= insert_start - EPS {
+                    if let Item::Clip(clip) = item {
+                        if let (Some(id), Some(sync_id)) = (
+                            item.get_id(),
+                            resolve_sync_clips_id(&clip.metadata),
+                        ) {
+                            clips.push((track_index, id, sync_id));
+                        }
+                    }
+                }
+                pos += item.duration().max(0.0);
+            }
+        }
+        clips
+    }
+}

--- a/tellers-timeline-core/src/stack_methods/stack_insert_propagate.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_insert_propagate.rs
@@ -1,9 +1,19 @@
 use crate::{
-    Gap, IdMetadataExt, InsertPolicy, Item, OverlapPolicy, Seconds, SplitClipInfo, Stack, TrackInsertResult,
+    Gap, IdMetadataExt, InsertPolicy, Item, OverlapPolicy, Seconds, SplitClipInfo, Stack,
+    TrackInsertResult,
 };
 use std::collections::{HashMap, HashSet};
 
-use super::{resolve_sync_clips_id, EPS};
+use super::{resolve_sync_clips_id, set_resolve_sync_clips_id, EPS};
+
+pub(super) type TrackInsertUpdate<'a> = (usize, &'a TrackInsertResult);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SplitOutcome {
+    BothSides,
+    LeftOnly,
+    RightOnly,
+}
 
 fn is_split_fragment(clip_id: &str, splits: &[SplitClipInfo]) -> bool {
     splits.iter().any(|split| {
@@ -12,11 +22,16 @@ fn is_split_fragment(clip_id: &str, splits: &[SplitClipInfo]) -> bool {
     })
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SplitOutcome {
-    BothSides,
-    LeftOnly,
-    RightOnly,
+fn updated_track_set(updates: &[TrackInsertUpdate<'_>]) -> HashSet<usize> {
+    updates.iter().map(|(track_index, _)| *track_index).collect()
+}
+
+fn all_split_clips(updates: &[TrackInsertUpdate<'_>]) -> Vec<SplitClipInfo> {
+    updates
+        .iter()
+        .flat_map(|(_, result)| result.split_clips.iter())
+        .cloned()
+        .collect()
 }
 
 impl Stack {
@@ -60,9 +75,6 @@ impl Stack {
             .map(|group| group.track_indices)
     }
 
-    /// Among sync clusters containing `track_index`, prefer one with a video track
-    /// when `prefer_cluster_with_video` is true (insert on a video track or using a
-    /// synced video clip), otherwise prefer the cluster with the most tracks.
     pub(super) fn preferred_cluster_indices(
         &self,
         track_index: usize,
@@ -78,9 +90,6 @@ impl Stack {
             .unwrap_or_else(|| vec![track_index])
     }
 
-    /// Resolve the working sync cluster for an insert. When a synced video clip is
-    /// used but the destination cluster has no video track, merge in the best cluster
-    /// that contains `preferred_video_track_id`.
     pub(super) fn resolve_insert_cluster(
         &self,
         dest_track_index: usize,
@@ -135,172 +144,412 @@ impl Stack {
         cluster
     }
 
-    /// Apply primary-track insert mutations to synced clips on partner tracks in `cluster`.
-    pub(super) fn propagate_track_insert_to_cluster(
+    /// Always run after a column insert: deleted sync clips, partner splits/gaps, then
+    /// right-fragment link-group ids for splits that cut through a sync group.
+    pub(super) fn propagate_insert_to_cluster(
         &mut self,
-        dest_track_index: usize,
         insert_start: Seconds,
         insert_duration: Seconds,
         overlap_policy: OverlapPolicy,
-        track_result: &TrackInsertResult,
+        updates: &[TrackInsertUpdate<'_>],
         cluster: &[usize],
         insert_sync_clips_id: Option<i64>,
-        column_tracks: &[usize],
+    ) -> bool {
+        if insert_duration <= EPS || updates.is_empty() {
+            return true;
+        }
+        let insert_end = insert_start + insert_duration;
+        let updated_tracks = updated_track_set(updates);
+        let all_splits = all_split_clips(updates);
+
+        if !self.propagate_deleted_sync_clips(updates, &all_splits) {
+            return false;
+        }
+        if !self.propagate_splits_to_cluster(
+            updates,
+            insert_start,
+            insert_end,
+            insert_duration,
+            overlap_policy,
+            cluster,
+            &updated_tracks,
+            insert_sync_clips_id,
+        ) {
+            return false;
+        }
+        true
+    }
+
+    /// Push-only: for sync groups present after the insert on updated tracks, push a gap
+    /// on cluster partners that were not part of the column insert.
+    pub(super) fn propagate_push_to_cluster(
+        &mut self,
+        insert_start: Seconds,
+        insert_end: Seconds,
+        insert_duration: Seconds,
+        updates: &[TrackInsertUpdate<'_>],
+        cluster: &[usize],
     ) -> bool {
         if insert_duration <= EPS {
             return true;
         }
-        let insert_end = insert_start + insert_duration;
+        let updated_tracks = updated_track_set(updates);
+        let sync_groups =
+            self.sync_groups_after_insert_on_tracks(&updated_tracks, insert_end, updates);
+        let aligned_start = self
+            .min_sync_clip_start_at_or_after(&updated_tracks, insert_end)
+            .unwrap_or(insert_end);
+        let cluster_set: HashSet<usize> = cluster.iter().copied().collect();
+        let mut used_ids = self.collect_timeline_ids();
 
-        let mut deleted_sync_ids = HashSet::new();
-        for deleted in &track_result.deleted_clips {
-            if is_split_fragment(&deleted.clip_id, &track_result.split_clips) {
-                continue;
+        if let Some(updated_leading) =
+            self.min_item_start_before_on_tracks(&updated_tracks, insert_start)
+        {
+            for &track_index in cluster {
+                if updated_tracks.contains(&track_index) {
+                    continue;
+                }
+                let Some(partner_first_sync) = self.first_sync_clip_start_on_track(track_index)
+                else {
+                    continue;
+                };
+                if partner_first_sync <= updated_leading + EPS {
+                    continue;
+                }
+                let gap_duration = partner_first_sync - updated_leading;
+                if gap_duration <= EPS
+                    || self.track_has_spacer_at(track_index, updated_leading, gap_duration)
+                {
+                    continue;
+                }
+                let mut gap = Item::Gap(Gap::make_gap(gap_duration));
+                Self::ensure_unique_item_id(&mut gap, &mut used_ids);
+                let result = self.children[track_index].insert_at_time(
+                    updated_leading,
+                    gap,
+                    OverlapPolicy::Push,
+                    InsertPolicy::SplitAndInsert,
+                );
+                if !result.success {
+                    return false;
+                }
             }
-            if let Some(sync_id) = deleted.sync_clips_id {
-                deleted_sync_ids.insert(sync_id);
+        }
+
+        for sync_id in sync_groups {
+            for (track_index, _) in self.synced_clips_targets(sync_id) {
+                if !cluster_set.contains(&track_index) || updated_tracks.contains(&track_index) {
+                    continue;
+                }
+                let Some(partner_sync_start) = self.first_cluster_sync_clip_start_at_or_after(
+                    track_index,
+                    insert_start,
+                    cluster,
+                ) else {
+                    continue;
+                };
+                let (gap_at, gap_duration) = if partner_sync_start <= insert_start + EPS {
+                    (insert_start, aligned_start - insert_start)
+                } else {
+                    (insert_start, aligned_start - partner_sync_start)
+                };
+                if gap_duration <= EPS {
+                    continue;
+                }
+                if partner_sync_start <= insert_start + EPS
+                    && self.track_has_spacer_at(track_index, gap_at, gap_duration)
+                {
+                    continue;
+                }
+                let mut gap = Item::Gap(Gap::make_gap(gap_duration));
+                Self::ensure_unique_item_id(&mut gap, &mut used_ids);
+                let result = self.children[track_index].insert_at_time(
+                    gap_at,
+                    gap,
+                    OverlapPolicy::Push,
+                    InsertPolicy::SplitAndInsert,
+                );
+                if !result.success {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    fn min_sync_clip_start_at_or_after(
+        &self,
+        track_indices: &HashSet<usize>,
+        threshold: Seconds,
+    ) -> Option<Seconds> {
+        let mut min_start: Option<Seconds> = None;
+        for &track_index in track_indices {
+            let Some(track) = self.children.get(track_index) else {
+                continue;
+            };
+            let mut pos = 0.0;
+            for item in &track.items {
+                if pos >= threshold - EPS {
+                    if let Item::Clip(clip) = item {
+                        if clip.sync_clips_id().is_some() {
+                            min_start = Some(match min_start {
+                                Some(current) => current.min(pos),
+                                None => pos,
+                            });
+                        }
+                    }
+                }
+                pos += item.duration().max(0.0);
+            }
+        }
+        min_start
+    }
+
+    fn min_item_start_before_on_tracks(
+        &self,
+        track_indices: &HashSet<usize>,
+        insert_start: Seconds,
+    ) -> Option<Seconds> {
+        let mut min_start: Option<Seconds> = None;
+        for &track_index in track_indices {
+            let Some(track) = self.children.get(track_index) else {
+                continue;
+            };
+            let mut pos = 0.0;
+            for item in &track.items {
+                if pos >= insert_start - EPS {
+                    break;
+                }
+                min_start = Some(match min_start {
+                    Some(current) => current.min(pos),
+                    None => pos,
+                });
+                pos += item.duration().max(0.0);
+            }
+        }
+        min_start
+    }
+
+    fn first_sync_clip_start_on_track(&self, track_index: usize) -> Option<Seconds> {
+        let track = self.children.get(track_index)?;
+        let mut pos = 0.0;
+        for item in &track.items {
+            if let Item::Clip(clip) = item {
+                if clip.sync_clips_id().is_some() {
+                    return Some(pos);
+                }
+            }
+            pos += item.duration().max(0.0);
+        }
+        None
+    }
+
+    fn first_cluster_sync_clip_start_at_or_after(
+        &self,
+        track_index: usize,
+        insert_start: Seconds,
+        cluster: &[usize],
+    ) -> Option<Seconds> {
+        let track = self.children.get(track_index)?;
+        let cluster_sync_ids: HashSet<i64> = cluster
+            .iter()
+            .filter_map(|&index| self.children.get(index))
+            .flat_map(|track| track.items.iter())
+            .filter_map(|item| match item {
+                Item::Clip(clip) => clip.sync_clips_id(),
+                Item::Gap(_) => None,
+            })
+            .collect();
+        let mut pos = 0.0;
+        let mut any_sync_start: Option<Seconds> = None;
+        for item in &track.items {
+            if pos + item.duration().max(0.0) > insert_start + EPS {
+                if let Item::Clip(clip) = item {
+                    if let Some(sync_id) = clip.sync_clips_id() {
+                        if cluster_sync_ids.is_empty() || cluster_sync_ids.contains(&sync_id) {
+                            return Some(pos);
+                        }
+                        any_sync_start = Some(any_sync_start.map_or(pos, |current| current.min(pos)));
+                    }
+                }
+            }
+            pos += item.duration().max(0.0);
+        }
+        any_sync_start
+    }
+
+    fn propagate_deleted_sync_clips(
+        &mut self,
+        updates: &[TrackInsertUpdate<'_>],
+        all_splits: &[SplitClipInfo],
+    ) -> bool {
+        let mut deleted_sync_ids = HashSet::new();
+        for (_, result) in updates {
+            for deleted in &result.deleted_clips {
+                if is_split_fragment(&deleted.clip_id, all_splits) {
+                    continue;
+                }
+                if let Some(sync_id) = deleted.sync_clips_id {
+                    deleted_sync_ids.insert(sync_id);
+                }
             }
         }
         for sync_id in deleted_sync_ids {
             self.delete_sync_clips(sync_id, true);
         }
-
-        let split_outcomes = self.classify_split_outcomes(
-            track_result,
-            dest_track_index,
-            insert_start,
-            insert_end,
-        );
-        if overlap_policy != OverlapPolicy::Push {
-            for (split, outcome) in split_outcomes {
-                let Some(sync_clips_id) = split.sync_clips_id else {
-                    continue;
-                };
-                match outcome {
-                    SplitOutcome::BothSides => {
-                        let right_sync_clips_id = match insert_sync_clips_id {
-                            Some(id) => id,
-                            None if overlap_policy == OverlapPolicy::Override => {
-                                self.next_sync_clips_id()
-                            }
-                            None => sync_clips_id,
-                        };
-                        if !self.propagate_full_split_to_sync_group(
-                            sync_clips_id,
-                            split.split_time,
-                            insert_start,
-                            insert_duration,
-                            overlap_policy,
-                            cluster,
-                            dest_track_index,
-                            right_sync_clips_id,
-                        ) {
-                            return false;
-                        }
-                    }
-                    SplitOutcome::LeftOnly | SplitOutcome::RightOnly => {
-                        if !self.propagate_partial_split_to_sync_group(
-                            sync_clips_id,
-                            insert_start,
-                            insert_end,
-                            overlap_policy,
-                            cluster,
-                            dest_track_index,
-                        ) {
-                            return false;
-                        }
-                    }
-                }
-            }
-        }
-
-        if overlap_policy == OverlapPolicy::Push {
-            return self.propagate_push_insert_to_cluster(
-                dest_track_index,
-                insert_start,
-                insert_duration,
-                cluster,
-                column_tracks,
-            );
-        }
-
         true
     }
 
-    fn classify_split_outcomes(
-        &self,
-        track_result: &TrackInsertResult,
-        dest_track_index: usize,
+    fn propagate_splits_to_cluster(
+        &mut self,
+        updates: &[TrackInsertUpdate<'_>],
         insert_start: Seconds,
         insert_end: Seconds,
-    ) -> Vec<(SplitClipInfo, SplitOutcome)> {
-        let mut by_sync_id: HashMap<i64, SplitClipInfo> = HashMap::new();
-        for split in &track_result.split_clips {
+        insert_duration: Seconds,
+        overlap_policy: OverlapPolicy,
+        cluster: &[usize],
+        updated_tracks: &HashSet<usize>,
+        insert_sync_clips_id: Option<i64>,
+    ) -> bool {
+        let mut splits_by_source: Vec<(usize, SplitClipInfo)> = Vec::new();
+        for &(track_index, result) in updates {
+            for split in &result.split_clips {
+                splits_by_source.push((track_index, split.clone()));
+            }
+        }
+
+        let mut by_sync_id: HashMap<i64, (usize, SplitClipInfo)> = HashMap::new();
+        for (source_track, split) in splits_by_source {
             let Some(sync_id) = split.sync_clips_id else {
                 continue;
             };
             by_sync_id
                 .entry(sync_id)
-                .and_modify(|existing| {
-                    if existing.split_time > split.split_time {
+                .and_modify(|(existing_source, existing)| {
+                    if split.split_time < existing.split_time {
                         existing.split_time = split.split_time;
                     }
                     if existing.old_clip_id.is_empty() {
                         existing.old_clip_id = split.old_clip_id.clone();
                     }
+                    if split.split_time < existing.split_time {
+                        *existing_source = source_track;
+                    }
                 })
-                .or_insert_with(|| split.clone());
+                .or_insert_with(|| (source_track, split));
         }
 
-        by_sync_id
-            .into_values()
-            .filter_map(|split| {
-                let sync_id = split.sync_clips_id?;
-                let mut has_left = false;
-                let mut has_right = false;
-                for (track_index, item_index) in self.synced_clips_targets(sync_id) {
-                    if track_index != dest_track_index {
-                        continue;
+        for (sync_id, (source_track, split)) in by_sync_id {
+            let outcome = self.classify_split_outcome(
+                &split,
+                source_track,
+                insert_start,
+                insert_end,
+            );
+
+            if !self.split_sync_partners_at_time(
+                sync_id,
+                split.split_time,
+                cluster,
+                updated_tracks,
+            ) {
+                return false;
+            }
+
+            let Some(outcome) = outcome else {
+                continue;
+            };
+
+            let right_sync_clips_id = match (insert_sync_clips_id, overlap_policy) {
+                (Some(id), OverlapPolicy::Override) => id,
+                (Some(_), OverlapPolicy::Push) => self.next_sync_clips_id(),
+                (None, OverlapPolicy::Override) => self.next_sync_clips_id(),
+                (None, OverlapPolicy::Push) => sync_id,
+            };
+
+            match (overlap_policy, outcome) {
+                (OverlapPolicy::Override, SplitOutcome::BothSides) => {
+                    if !self.insert_override_gap_on_cluster_partners(
+                        insert_start,
+                        insert_duration,
+                        cluster,
+                        updated_tracks,
+                    ) {
+                        return false;
                     }
-                    let start = self.children[track_index].start_time_of_item(item_index);
-                    if start + EPS < insert_start {
-                        has_left = true;
-                    }
-                    if start >= insert_end - EPS {
-                        has_right = true;
+                    let right_start_threshold = split.split_time + insert_duration - EPS;
+                    self.reassign_right_sync_group_ids(
+                        sync_id,
+                        right_start_threshold,
+                        right_sync_clips_id,
+                    );
+                }
+                (OverlapPolicy::Override, SplitOutcome::LeftOnly | SplitOutcome::RightOnly) => {
+                    if !self.delete_sync_range_on_cluster_partners(
+                        sync_id,
+                        insert_start,
+                        insert_end,
+                        cluster,
+                        updated_tracks,
+                    ) {
+                        return false;
                     }
                 }
-                let outcome = match (has_left, has_right) {
-                    (true, true) => SplitOutcome::BothSides,
-                    (true, false) => SplitOutcome::LeftOnly,
-                    (false, true) => SplitOutcome::RightOnly,
-                    (false, false) => return None,
-                };
-                Some((split, outcome))
-            })
-            .collect()
+                (OverlapPolicy::Push, SplitOutcome::BothSides) => {
+                    let right_start_threshold = split.split_time + insert_duration - EPS;
+                    self.reassign_right_sync_group_ids(
+                        sync_id,
+                        right_start_threshold,
+                        right_sync_clips_id,
+                    );
+                }
+                _ => {}
+            }
+        }
+        true
     }
 
-    fn propagate_full_split_to_sync_group(
+    fn classify_split_outcome(
+        &self,
+        split: &SplitClipInfo,
+        source_track_index: usize,
+        insert_start: Seconds,
+        insert_end: Seconds,
+    ) -> Option<SplitOutcome> {
+        let sync_id = split.sync_clips_id?;
+        let mut has_left = false;
+        let mut has_right = false;
+        for (track_index, item_index) in self.synced_clips_targets(sync_id) {
+            if track_index != source_track_index {
+                continue;
+            }
+            let start = self.children[track_index].start_time_of_item(item_index);
+            if start + EPS < insert_start {
+                has_left = true;
+            }
+            if start >= insert_end - EPS {
+                has_right = true;
+            }
+        }
+        match (has_left, has_right) {
+            (true, true) => Some(SplitOutcome::BothSides),
+            (true, false) => Some(SplitOutcome::LeftOnly),
+            (false, true) => Some(SplitOutcome::RightOnly),
+            (false, false) => None,
+        }
+    }
+
+    fn split_sync_partners_at_time(
         &mut self,
         sync_clips_id: i64,
         split_time: Seconds,
-        insert_start: Seconds,
-        insert_duration: Seconds,
-        overlap_policy: OverlapPolicy,
         cluster: &[usize],
-        dest_track_index: usize,
-        right_sync_clips_id: i64,
+        updated_tracks: &HashSet<usize>,
     ) -> bool {
-        let partner_tracks: Vec<usize> = cluster
-            .iter()
-            .copied()
-            .filter(|&track_index| track_index != dest_track_index)
-            .collect();
-
-        let mut used_ids = self.collect_timeline_ids();
-
-        for track_index in partner_tracks {
+        for &track_index in cluster {
+            if updated_tracks.contains(&track_index) {
+                continue;
+            }
             let needs_split = self.children.get(track_index).is_some_and(|track| {
                 track
                     .get_item_at_time(split_time)
@@ -311,116 +560,56 @@ impl Stack {
                     })
                     .is_some_and(|id| id == sync_clips_id)
             });
-
             if needs_split {
                 self.children[track_index].split_at_time(split_time);
             }
-
-            if self.track_has_spacer_at(track_index, insert_start, insert_duration) {
-                continue;
-            }
-
-            let mut gap = Item::Gap(Gap::make_gap(insert_duration));
-            Self::ensure_unique_item_id(&mut gap, &mut used_ids);
-            let gap_result = self.children[track_index].insert_at_time(
-                insert_start,
-                gap,
-                overlap_policy,
-                InsertPolicy::SplitAndInsert,
-            );
-            if !gap_result.success {
-                return false;
-            }
         }
-
-        let right_start_threshold = split_time + insert_duration - EPS;
-        for (track_index, item_index) in self.synced_clips_targets(sync_clips_id) {
-            let item_start = self.children[track_index].start_time_of_item(item_index);
-            if item_start < right_start_threshold {
-                continue;
-            }
-            let Some(Item::Clip(clip)) = self
-                .children
-                .get_mut(track_index)
-                .and_then(|track| track.items.get_mut(item_index))
-            else {
-                continue;
-            };
-            if resolve_sync_clips_id(&clip.metadata) != Some(sync_clips_id) {
-                continue;
-            }
-            super::set_resolve_sync_clips_id(&mut clip.metadata, right_sync_clips_id);
-        }
-
         true
     }
 
-    fn propagate_partial_split_to_sync_group(
+    fn insert_override_gap_on_cluster_partners(
+        &mut self,
+        insert_start: Seconds,
+        insert_duration: Seconds,
+        cluster: &[usize],
+        updated_tracks: &HashSet<usize>,
+    ) -> bool {
+        let mut used_ids = self.collect_timeline_ids();
+        for &track_index in cluster {
+            if updated_tracks.contains(&track_index) {
+                continue;
+            }
+            if self.track_has_spacer_at(track_index, insert_start, insert_duration) {
+                continue;
+            }
+            let mut gap = Item::Gap(Gap::make_gap(insert_duration));
+            Self::ensure_unique_item_id(&mut gap, &mut used_ids);
+            let result = self.children[track_index].insert_at_time(
+                insert_start,
+                gap,
+                OverlapPolicy::Override,
+                InsertPolicy::SplitAndInsert,
+            );
+            if !result.success {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn delete_sync_range_on_cluster_partners(
         &mut self,
         sync_clips_id: i64,
         insert_start: Seconds,
         insert_end: Seconds,
-        overlap_policy: OverlapPolicy,
         cluster: &[usize],
-        dest_track_index: usize,
+        updated_tracks: &HashSet<usize>,
     ) -> bool {
-        if overlap_policy == OverlapPolicy::Push {
-            let insert_duration = insert_end - insert_start;
-            if insert_duration <= EPS {
-                return true;
-            }
-            let mut used_ids = self.collect_timeline_ids();
-            for track_index in cluster {
-                if *track_index == dest_track_index {
-                    continue;
-                }
-                let Some(track) = self.children.get(*track_index) else {
-                    continue;
-                };
-                let has_sync_clip_in_range = {
-                    let mut pos = 0.0;
-                    let mut found = false;
-                    for item in &track.items {
-                        let item_start = pos;
-                        let item_end = pos + item.duration().max(0.0);
-                        if item_end > insert_start + EPS && item_start < insert_end - EPS {
-                            if let Item::Clip(clip) = item {
-                                if resolve_sync_clips_id(&clip.metadata) == Some(sync_clips_id) {
-                                    found = true;
-                                    break;
-                                }
-                            }
-                        }
-                        pos = item_end;
-                    }
-                    found
-                };
-                if !has_sync_clip_in_range {
-                    continue;
-                }
-                if self.track_has_spacer_at(*track_index, insert_start, insert_duration) {
-                    continue;
-                }
-                let mut gap = Item::Gap(Gap::make_gap(insert_duration));
-                Self::ensure_unique_item_id(&mut gap, &mut used_ids);
-                let result = self.children[*track_index].insert_at_time(
-                    insert_start,
-                    gap,
-                    OverlapPolicy::Push,
-                    InsertPolicy::SplitAndInsert,
-                );
-                if !result.success {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        for track_index in cluster {
-            if *track_index == dest_track_index {
+        for &track_index in cluster {
+            if updated_tracks.contains(&track_index) {
                 continue;
             }
-            let Some(track) = self.children.get(*track_index) else {
+            let Some(track) = self.children.get(track_index) else {
                 continue;
             };
             let has_sync_clip_in_range = {
@@ -444,111 +633,67 @@ impl Stack {
             if !has_sync_clip_in_range {
                 continue;
             }
-            self.children[*track_index].delete_range(insert_start, insert_end, true);
+            self.children[track_index].delete_range(insert_start, insert_end, true);
         }
         true
     }
 
-    fn propagate_push_insert_to_cluster(
+    fn reassign_right_sync_group_ids(
         &mut self,
-        dest_track_index: usize,
-        insert_start: Seconds,
-        insert_duration: Seconds,
-        cluster: &[usize],
-        column_tracks: &[usize],
-    ) -> bool {
-        let column_track_set: HashSet<usize> = column_tracks.iter().copied().collect();
-        let push_anchor = insert_start + insert_duration;
-        let dest_right_start = self.children.get(dest_track_index).and_then(|track| {
+        sync_clips_id: i64,
+        right_start_threshold: Seconds,
+        right_sync_clips_id: i64,
+    ) {
+        for (track_index, item_index) in self.synced_clips_targets(sync_clips_id) {
+            let item_start = self.children[track_index].start_time_of_item(item_index);
+            if item_start < right_start_threshold {
+                continue;
+            }
+            let Some(Item::Clip(clip)) = self
+                .children
+                .get_mut(track_index)
+                .and_then(|track| track.items.get_mut(item_index))
+            else {
+                continue;
+            };
+            if resolve_sync_clips_id(&clip.metadata) != Some(sync_clips_id) {
+                continue;
+            }
+            set_resolve_sync_clips_id(&mut clip.metadata, right_sync_clips_id);
+        }
+    }
+
+    fn sync_groups_after_insert_on_tracks(
+        &self,
+        updated_tracks: &HashSet<usize>,
+        insert_end: Seconds,
+        updates: &[TrackInsertUpdate<'_>],
+    ) -> HashSet<i64> {
+        let mut sync_ids = HashSet::new();
+        for &track_index in updated_tracks {
+            let Some(track) = self.children.get(track_index) else {
+                continue;
+            };
             let mut pos = 0.0;
-            let mut min_start: Option<Seconds> = None;
             for item in &track.items {
-                if pos >= push_anchor - EPS {
+                if pos >= insert_end - EPS {
                     if let Item::Clip(clip) = item {
-                        if resolve_sync_clips_id(&clip.metadata).is_some() {
-                            min_start = Some(match min_start {
-                                Some(current) => current.min(pos),
-                                None => pos,
-                            });
+                        if let Some(sync_id) = clip.sync_clips_id() {
+                            sync_ids.insert(sync_id);
                         }
                     }
                 }
                 pos += item.duration().max(0.0);
             }
-            min_start
-        });
-
-        let dest_right_start = dest_right_start.unwrap_or(push_anchor);
-        let mut used_ids = self.collect_timeline_ids();
-        for &track_index in cluster {
-            if track_index == dest_track_index || column_track_set.contains(&track_index) {
-                continue;
-            }
-            let Some(partner_sync_start) =
-                self.first_cluster_sync_clip_start_at_or_after(track_index, insert_start, cluster)
-            else {
-                continue;
-            };
-            let (gap_at, gap_duration) = if partner_sync_start <= insert_start + EPS {
-                (insert_start, dest_right_start - insert_start)
-            } else {
-                (insert_start, dest_right_start - partner_sync_start)
-            };
-            if gap_duration <= EPS {
-                continue;
-            }
-            if partner_sync_start <= insert_start + EPS
-                && self.track_has_spacer_at(track_index, gap_at, gap_duration)
-            {
-                continue;
-            }
-            let mut gap = Item::Gap(Gap::make_gap(gap_duration));
-            Self::ensure_unique_item_id(&mut gap, &mut used_ids);
-            let result = self.children[track_index].insert_at_time(
-                gap_at,
-                gap,
-                OverlapPolicy::Push,
-                InsertPolicy::SplitAndInsert,
-            );
-            if !result.success {
-                return false;
-            }
         }
-        true
-    }
-
-    fn first_cluster_sync_clip_start_at_or_after(
-        &self,
-        track_index: usize,
-        insert_start: Seconds,
-        cluster: &[usize],
-    ) -> Option<Seconds> {
-        let track = self.children.get(track_index)?;
-        let cluster_sync_ids: HashSet<i64> = cluster
-            .iter()
-            .filter_map(|&index| self.children.get(index))
-            .flat_map(|track| track.items.iter())
-            .filter_map(|item| match item {
-                Item::Clip(clip) => resolve_sync_clips_id(&clip.metadata),
-                Item::Gap(_) => None,
-            })
-            .collect();
-        let mut pos = 0.0;
-        let mut any_sync_start: Option<Seconds> = None;
-        for item in &track.items {
-            if pos + item.duration().max(0.0) > insert_start + EPS {
-                if let Item::Clip(clip) = item {
-                    if let Some(sync_id) = resolve_sync_clips_id(&clip.metadata) {
-                        if cluster_sync_ids.is_empty() || cluster_sync_ids.contains(&sync_id) {
-                            return Some(pos);
-                        }
-                        any_sync_start = Some(any_sync_start.map_or(pos, |current| current.min(pos)));
-                    }
+        for (_, result) in updates {
+            for split in &result.split_clips {
+                if let Some(sync_id) = split.sync_clips_id {
+                    sync_ids.insert(sync_id);
                 }
             }
-            pos += item.duration().max(0.0);
         }
-        any_sync_start
+        sync_ids
     }
 
     pub(super) fn track_has_spacer_at(
@@ -566,10 +711,10 @@ impl Stack {
         if (track.start_time_of_item(item_index) - start).abs() > EPS {
             return false;
         }
-        (track.items[item_index].duration() - duration).abs() <= EPS
+        matches!(track.items[item_index], Item::Gap(_))
+            && (track.items[item_index].duration() - duration).abs() <= EPS
     }
 
-    /// Sync clips on partner tracks that start at or after `insert_start`.
     pub(super) fn sync_clips_after_time_in_cluster(
         &self,
         insert_start: Seconds,
@@ -588,10 +733,9 @@ impl Stack {
             for item in &track.items {
                 if pos >= insert_start - EPS {
                     if let Item::Clip(clip) = item {
-                        if let (Some(id), Some(sync_id)) = (
-                            item.get_id(),
-                            resolve_sync_clips_id(&clip.metadata),
-                        ) {
+                        if let (Some(id), Some(sync_id)) =
+                            (item.get_id(), resolve_sync_clips_id(&clip.metadata))
+                        {
                             clips.push((track_index, id, sync_id));
                         }
                     }

--- a/tellers-timeline-core/src/stack_methods/stack_item_insert.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_item_insert.rs
@@ -26,6 +26,8 @@ impl Stack {
             insert_policy,
             synced_audio_clips,
             synced_video_clip,
+            None,
+            None,
         )
     }
 
@@ -56,6 +58,8 @@ impl Stack {
             InsertPolicy::InsertBefore,
             synced_audio_clips,
             synced_video_clip,
+            None,
+            None,
         )
     }
 }

--- a/tellers-timeline-core/src/stack_methods/stack_item_insert.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_item_insert.rs
@@ -26,8 +26,8 @@ impl Stack {
             insert_policy,
             synced_audio_clips,
             synced_video_clip,
-            None,
-            None,
+            None::<&str>,
+            None::<&[usize]>,
         )
     }
 
@@ -58,8 +58,8 @@ impl Stack {
             InsertPolicy::InsertBefore,
             synced_audio_clips,
             synced_video_clip,
-            None,
-            None,
+            None::<&str>,
+            None::<&[usize]>,
         )
     }
 }

--- a/tellers-timeline-core/src/stack_methods/stack_item_insert.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_item_insert.rs
@@ -28,6 +28,7 @@ impl Stack {
             synced_video_clip,
             None::<&str>,
             None::<&[usize]>,
+            None::<&[usize]>,
         )
     }
 
@@ -59,6 +60,7 @@ impl Stack {
             synced_audio_clips,
             synced_video_clip,
             None::<&str>,
+            None::<&[usize]>,
             None::<&[usize]>,
         )
     }

--- a/tellers-timeline-core/src/stack_methods/stack_item_link.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_item_link.rs
@@ -1,7 +1,5 @@
-use crate::{Item, Seconds, Stack};
+use crate::{Item, Stack};
 use std::collections::HashSet;
-
-const EPS: Seconds = super::EPS;
 
 impl Stack {
     pub fn unsync_item(&mut self, item_ids: &[String]) -> usize {
@@ -52,17 +50,6 @@ impl Stack {
         }
         if targets.len() < 2 {
             return None;
-        }
-
-        let (first_track_index, first_item_index) = targets[0];
-        let first_start = self.children[first_track_index].start_time_of_item(first_item_index);
-        let first_duration = self.children[first_track_index].items[first_item_index].duration();
-        for (track_index, item_index) in targets.iter().skip(1) {
-            let start = self.children[*track_index].start_time_of_item(*item_index);
-            let duration = self.children[*track_index].items[*item_index].duration();
-            if (start - first_start).abs() > EPS || (duration - first_duration).abs() > EPS {
-                return None;
-            }
         }
 
         let backup = self.clone();

--- a/tellers-timeline-core/src/track_methods/mod.rs
+++ b/tellers-timeline-core/src/track_methods/mod.rs
@@ -4,4 +4,6 @@ pub mod track_item_insert;
 pub mod track_item_replace;
 pub mod track_item_split;
 
-pub use track_item_insert::{InsertPolicy, OverlapPolicy};
+pub use track_item_insert::{
+    DeletedClipInfo, InsertPolicy, OverlapPolicy, SplitClipInfo, TrackInsertResult,
+};

--- a/tellers-timeline-core/src/track_methods/track_item_insert.rs
+++ b/tellers-timeline-core/src/track_methods/track_item_insert.rs
@@ -1,4 +1,4 @@
-use crate::{Item, Seconds, Track};
+use crate::{IdMetadataExt, Item, Seconds, Track};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OverlapPolicy {
@@ -19,20 +19,57 @@ pub enum InsertPolicy {
     InsertBeforeOrAfter,
 }
 
+/// A clip that was split during insert. `left_clip_id` and `right_clip_id` are
+/// optional because override insertion may trim away one side.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SplitClipInfo {
+    pub old_clip_id: String,
+    pub left_clip_id: Option<String>,
+    pub right_clip_id: Option<String>,
+    pub sync_clips_id: Option<i64>,
+    pub split_time: Seconds,
+}
+
+/// A clip removed during override insert.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeletedClipInfo {
+    pub clip_id: String,
+    pub sync_clips_id: Option<i64>,
+}
+
+/// Result of a track-level insert: deleted clips, splits, and success flag.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct TrackInsertResult {
+    pub success: bool,
+    pub deleted_clips: Vec<DeletedClipInfo>,
+    pub split_clips: Vec<SplitClipInfo>,
+}
+
+impl TrackInsertResult {
+    pub(crate) fn merge(&mut self, other: TrackInsertResult) {
+        self.success = self.success && other.success;
+        self.deleted_clips.extend(other.deleted_clips);
+        self.split_clips.extend(other.split_clips);
+    }
+}
+
 impl Track {
     pub(crate) fn insert_at_index(
         &mut self,
         index: usize,
         mut item: Item,
         overlap_policy: OverlapPolicy,
-    ) {
+    ) -> TrackInsertResult {
         item.clamp_to_active_available_range();
         if overlap_policy == OverlapPolicy::Push {
             self.insert_and_push(index, item);
-            return;
+            return TrackInsertResult {
+                success: true,
+                ..Default::default()
+            };
         }
 
-        self.insert_and_override(index, item);
+        self.insert_and_override(index, item)
     }
 
     pub(crate) fn insert_and_push(&mut self, index: usize, mut item: Item) {
@@ -40,9 +77,14 @@ impl Track {
         self.items.insert(index, item);
     }
 
-    pub(crate) fn insert_and_override(&mut self, index: usize, mut item: Item) {
+    pub(crate) fn insert_and_override(&mut self, index: usize, mut item: Item) -> TrackInsertResult {
         const EPS: Seconds = 1e-9;
         item.clamp_to_active_available_range();
+
+        let mut result = TrackInsertResult {
+            success: true,
+            ..Default::default()
+        };
 
         let mut insert_index = index.min(self.items.len());
         let insert_start = self.start_time_of_item(insert_index);
@@ -51,14 +93,16 @@ impl Track {
         if item.duration() <= EPS {
             self.items.insert(insert_index, item);
             self.sanitize_preserving_all_gap_track();
-            return;
+            return result;
         }
 
         // If the insertion start falls strictly inside an item at insert_index, split at start
         if let Some(containing_idx) = self.get_item_at_time(insert_start) {
             let containing_start = self.start_time_of_item(containing_idx);
             if insert_start > containing_start + EPS && containing_idx <= insert_index {
-                self.split_at_time(insert_start);
+                if let Some(split) = self.split_at_time(insert_start) {
+                    result.split_clips.push(split);
+                }
                 // After split, the right piece is at containing_idx + 1; our insertion point is after the left piece
                 if insert_index <= containing_idx {
                     insert_index = containing_idx + 1;
@@ -70,7 +114,9 @@ impl Track {
 
         // Split at end boundary if it falls inside an item
         if self.get_item_at_time(insert_end).is_some() {
-            self.split_at_time(insert_end);
+            if let Some(split) = self.split_at_time(insert_end) {
+                result.split_clips.push(split);
+            }
         }
 
         // After splitting at start and end, remove the exact range of items fully inside [insert_start, insert_end).
@@ -80,12 +126,19 @@ impl Track {
         if end_index > insert_index {
             let remove_count = end_index - insert_index;
             for _ in 0..remove_count {
+                if let Item::Clip(clip) = &self.items[insert_index] {
+                    result.deleted_clips.push(DeletedClipInfo {
+                        clip_id: clip.get_id().unwrap_or_default(),
+                        sync_clips_id: clip.sync_clips_id(),
+                    });
+                }
                 self.items.remove(insert_index);
             }
         }
 
         self.items.insert(insert_index, item);
         self.sanitize_preserving_all_gap_track();
+        result
     }
 
     /// Insert an item at a timeline time, controlling how overlaps are handled
@@ -96,7 +149,7 @@ impl Track {
         mut item: Item,
         overlap_policy: OverlapPolicy,
         insert_policy: InsertPolicy,
-    ) {
+    ) -> TrackInsertResult {
         item.clamp_to_active_available_range();
         let mut effective_insert_time = insert_time;
         let total_track_duration = self.total_duration();
@@ -118,19 +171,30 @@ impl Track {
                 .push(Item::Gap(crate::types::Gap::make_gap(gap_duration)));
             self.items.push(item);
             self.sanitize_preserving_all_gap_track();
-            return;
+            return TrackInsertResult {
+                success: true,
+                ..Default::default()
+            };
         }
 
         let containing_index = self.get_item_at_time(effective_insert_time);
 
         let insert_index = self.get_insertion_index(effective_insert_time, insert_policy);
 
+        let mut result = TrackInsertResult {
+            success: true,
+            ..Default::default()
+        };
+
         if let (InsertPolicy::SplitAndInsert, Some(_i)) = (insert_policy, containing_index) {
             // Create the boundary at the insertion time before inserting.
-            self.split_at_time(effective_insert_time);
+            if let Some(split) = self.split_at_time(effective_insert_time) {
+                result.split_clips.push(split);
+            }
         }
 
-        self.insert_at_index(insert_index, item, overlap_policy);
+        result.merge(self.insert_at_index(insert_index, item, overlap_policy));
+        result
     }
 
     /// Compute the insertion index according to the policy without.

--- a/tellers-timeline-core/src/track_methods/track_item_split.rs
+++ b/tellers-timeline-core/src/track_methods/track_item_split.rs
@@ -1,11 +1,14 @@
-use crate::{Seconds, Track};
+use crate::{IdMetadataExt, Seconds, Track};
+
+use super::track_item_insert::SplitClipInfo;
 
 impl Track {
-    pub(crate) fn split_at_time(&mut self, split_time: Seconds) {
+    /// Split the item at `split_time`. Returns split metadata when a clip was split.
+    pub(crate) fn split_at_time(&mut self, split_time: Seconds) -> Option<SplitClipInfo> {
         const EPS: Seconds = 1e-9;
 
         let Some(item_index) = self.get_item_at_time(split_time) else {
-            return;
+            return None;
         };
 
         // Compute the offset from the start of the item
@@ -13,7 +16,7 @@ impl Track {
         let local_offset = split_time - item_start_time;
 
         if local_offset <= EPS {
-            return;
+            return None;
         }
 
         // Move the item out to avoid borrow issues
@@ -26,11 +29,13 @@ impl Track {
                 if local_offset >= total - EPS {
                     // Nothing to split, put the original back
                     self.items.insert(item_index, crate::Item::Clip(clip));
-                    return;
+                    return None;
                 }
 
                 let left_duration = local_offset.max(0.0);
                 let right_duration = (total - left_duration).max(0.0);
+                let old_clip_id = clip.get_id().unwrap_or_default();
+                let sync_clips_id = clip.sync_clips_id();
 
                 let mut left_clip = clip.clone();
                 left_clip
@@ -50,15 +55,28 @@ impl Track {
                     &mut clip,
                     Some(crate::types::gen_hex_id_12()),
                 );
+                let right_clip_id = clip.get_id();
 
                 self.items.insert(item_index, crate::Item::Clip(left_clip));
                 self.items.insert(item_index + 1, crate::Item::Clip(clip));
+
+                if old_clip_id.is_empty() {
+                    return None;
+                }
+
+                Some(SplitClipInfo {
+                    old_clip_id,
+                    left_clip_id: self.items[item_index].get_id(),
+                    right_clip_id,
+                    sync_clips_id,
+                    split_time,
+                })
             }
             crate::Item::Gap(mut gap) => {
                 let total = gap.source_range.duration.to_seconds().max(0.0);
                 if local_offset >= total - EPS {
                     self.items.insert(item_index, crate::Item::Gap(gap));
-                    return;
+                    return None;
                 }
 
                 let left_duration = local_offset.max(0.0);
@@ -78,6 +96,7 @@ impl Track {
 
                 self.items.insert(item_index, crate::Item::Gap(left_gap));
                 self.items.insert(item_index + 1, crate::Item::Gap(gap));
+                None
             }
         }
     }

--- a/tellers-timeline-core/src/types.rs
+++ b/tellers-timeline-core/src/types.rs
@@ -396,6 +396,21 @@ impl Clip {
             .set_from_seconds((clamped_end - source_start).max(0.0));
     }
 
+    /// Resolve link-group sync id from Resolve OTIO metadata (`Link Group ID`).
+    pub fn sync_clips_id(&self) -> Option<i64> {
+        Self::resolve_otio_i64(&self.metadata, "Link Group ID")
+    }
+
+    pub(crate) fn resolve_otio_i64(metadata: &serde_json::Value, key: &str) -> Option<i64> {
+        let raw = metadata
+            .get("Resolve_OTIO")
+            .or_else(|| metadata.get("resolve"))
+            .and_then(|v| v.get(key))?;
+        raw.as_i64()
+            .or_else(|| raw.as_u64().and_then(|value| i64::try_from(value).ok()))
+            .or_else(|| raw.as_str().and_then(|value| value.parse::<i64>().ok()))
+    }
+
     pub fn new_single_media_reference(
         source_range: TimeRange,
         reference: MediaReference,

--- a/tellers-timeline-core/tests/synced.rs
+++ b/tellers-timeline-core/tests/synced.rs
@@ -3629,7 +3629,8 @@ fn move_synced_clip_between_boundaries_override_splits_destination_link_groups()
     let right_group = sync_clips_id(&video_track.items[right_index]);
     assert_eq!(left_group, Some(dest_group));
     assert_ne!(left_group, right_group);
-    assert_eq!(right_group, Some(dest_group + 1));
+    assert_ne!(right_group, moving_group);
+    assert_eq!(right_group, Some(dest_group + 1).max(moving_group.map(|id| id + 1)));
 
     let audio_track = &stack.children[dest_audio_index];
     let audio_left_index = audio_track.get_item_at_time(0.5).unwrap();

--- a/tellers-timeline-core/tests/synced.rs
+++ b/tellers-timeline-core/tests/synced.rs
@@ -3713,6 +3713,60 @@ fn move_synced_video_creates_only_missing_destination_audio_tracks() {
 }
 
 #[test]
+fn move_synced_set_creates_audio_track_when_preferred_track_has_content() {
+    let mut stack = Stack::default();
+    let mut video = Track::new(TrackKind::Video, Some("d-v".to_string()));
+    video
+        .items
+        .push(Item::Gap(Gap::make_gap(5.0)));
+    video
+        .items
+        .push(Item::Clip(clip(3.0, Some("d-vid"))));
+    let mut audio0 = Track::new(TrackKind::Audio, Some("d-a0".to_string()));
+    audio0.items.push(Item::Gap(Gap::make_gap(5.0)));
+    let mut a0 = audio_clip(3.0, "file:///d-a0.wav", None);
+    a0.set_id(Some("d-aud0".to_string()));
+    audio0.items.push(a0);
+    let mut audio1 = Track::new(TrackKind::Audio, Some("d-a1".to_string()));
+    audio1
+        .items
+        .push(Item::Clip(clip(2.0, Some("occupant"))));
+    audio1.items.push(Item::Gap(Gap::make_gap(3.0)));
+    let mut a1 = audio_clip(3.0, "file:///d-a1.wav", None);
+    a1.set_id(Some("d-aud1".to_string()));
+    audio1.items.push(a1);
+    stack.children.push(video);
+    stack.children.push(audio0);
+    stack.children.push(audio1);
+    stack
+        .sync_item(&[
+            "d-vid".to_string(),
+            "d-aud0".to_string(),
+            "d-aud1".to_string(),
+        ])
+        .unwrap();
+    let source_second_audio_track = stack.get_item("d-aud1").unwrap().0;
+    let track_count_before = stack.children.len();
+
+    assert!(stack.move_item_at_time(
+        "d-vid",
+        "d-v",
+        0.0,
+        true,
+        InsertPolicy::InsertBefore,
+        OverlapPolicy::Push,
+    ));
+
+    assert!(stack.children.len() > track_count_before);
+    let (_, second_audio_track, _) = stack.get_item("d-aud1").unwrap();
+    assert_ne!(
+        second_audio_track, source_second_audio_track,
+        "second audio must not land on a preferred track that already has clips at the move time"
+    );
+    assert_sync_clips_track_aligned(&stack, "move-busy-preferred-audio");
+}
+
+#[test]
 fn move_synced_video_at_index_uses_destination_boundary_without_retiming() {
     let mut stack = Stack::default();
     stack

--- a/tellers-timeline-core/tests/synced.rs
+++ b/tellers-timeline-core/tests/synced.rs
@@ -5711,7 +5711,7 @@ fn sync_item_links_arbitrary_existing_clips_with_new_group() {
 }
 
 #[test]
-fn sync_item_rejects_items_with_different_boundaries() {
+fn sync_item_links_clips_with_different_start_times() {
     let mut stack = Stack::default();
     let mut video = Track::new(TrackKind::Video, Some("v".to_string()));
     video.items.push(Item::Clip(clip(3.0, Some("primary"))));
@@ -5721,12 +5721,47 @@ fn sync_item_rejects_items_with_different_boundaries() {
     stack.children.push(video);
     stack.children.push(audio);
 
+    let group = stack
+        .sync_item(&["primary".to_string(), "audio".to_string()])
+        .unwrap();
+
     assert_eq!(
-        stack.sync_item(&["primary".to_string(), "audio".to_string()]),
-        None
+        sync_clips_id(stack.get_item("primary").unwrap().2),
+        Some(group)
     );
-    assert_eq!(sync_clips_id(stack.get_item("primary").unwrap().2), None);
-    assert_eq!(sync_clips_id(stack.get_item("audio").unwrap().2), None);
+    assert_eq!(sync_clips_id(stack.get_item("audio").unwrap().2), Some(group));
+    let (primary_track, primary_index, _) = stack.get_item("primary").unwrap();
+    let (audio_track, audio_index, _) = stack.get_item("audio").unwrap();
+    assert_eq!(
+        stack.children[primary_track].start_time_of_item(primary_index),
+        0.0
+    );
+    assert_eq!(
+        stack.children[audio_track].start_time_of_item(audio_index),
+        1.0
+    );
+}
+
+#[test]
+fn sync_item_links_clips_with_different_durations() {
+    let mut stack = Stack::default();
+    let mut video = Track::new(TrackKind::Video, Some("v".to_string()));
+    video.items.push(Item::Clip(clip(5.0, Some("primary"))));
+    let mut audio = Track::new(TrackKind::Audio, Some("a".to_string()));
+    audio.items.push(Item::Clip(clip(3.0, Some("audio"))));
+    stack.children.push(video);
+    stack.children.push(audio);
+
+    let group = stack
+        .sync_item(&["primary".to_string(), "audio".to_string()])
+        .unwrap();
+
+    let (_, _, primary_item) = stack.get_item("primary").unwrap();
+    let (_, _, audio_item) = stack.get_item("audio").unwrap();
+    assert_eq!(sync_clips_id(primary_item), Some(group));
+    assert_eq!(sync_clips_id(audio_item), Some(group));
+    assert_eq!(primary_item.duration(), 5.0);
+    assert_eq!(audio_item.duration(), 3.0);
 }
 
 // ---------------------------------------------------------------------------

--- a/tellers-timeline-core/tests/synced.rs
+++ b/tellers-timeline-core/tests/synced.rs
@@ -3687,16 +3687,22 @@ fn move_synced_video_creates_only_missing_destination_audio_tracks() {
         OverlapPolicy::Override,
     ));
 
-    // The synced audio partners keep their original source tracks when moved via insert.
-    assert_eq!(stack.children.len(), track_count);
+    // Destination-cluster audio tracks are preferred over the original source tracks.
+    assert_eq!(stack.children.len(), track_count + 1);
     let (first_audio_track, _, _) = stack.get_item(&first_audio_id).unwrap();
     let (second_audio_track, _, second_audio_item) = stack.get_item(&second_audio_id).unwrap();
-    assert!(source_audio_track_ids.contains(
-        &stack.children[first_audio_track].get_id().unwrap()
-    ));
-    assert!(source_audio_track_ids.contains(
-        &stack.children[second_audio_track].get_id().unwrap()
-    ));
+    assert_eq!(
+        stack.children[first_audio_track].get_id().as_deref(),
+        Some("dest-a")
+    );
+    assert_ne!(
+        stack.children[second_audio_track].get_id().as_deref(),
+        Some("dest-a")
+    );
+    assert!(
+        !source_audio_track_ids.contains(&stack.children[second_audio_track].get_id().unwrap()),
+        "second audio should not remain on a source-cluster track when dest-a is available"
+    );
     assert_eq!(second_audio_item.duration(), 3.0);
     assert_eq!(
         stack.children[stack.get_item("primary").unwrap().0]
@@ -3764,6 +3770,49 @@ fn move_synced_set_creates_audio_track_when_preferred_track_has_content() {
         "second audio must not land on a preferred track that already has clips at the move time"
     );
     assert_sync_clips_track_aligned(&stack, "move-busy-preferred-audio");
+}
+
+#[test]
+fn move_synced_video_to_upper_cluster_uses_destination_audio_tracks() {
+    const AUDIO_COUNT: usize = 8;
+
+    let mut stack = Stack::default();
+    push_empty_dest(&mut stack, "upper", AUDIO_COUNT, 20.0);
+    push_sync_set(&mut stack, "lower", 3.0, AUDIO_COUNT);
+
+    assert!(stack.move_item_at_time(
+        "lower-vid",
+        "upper-v",
+        0.0,
+        true,
+        InsertPolicy::SplitAndInsert,
+        OverlapPolicy::Override,
+    ));
+
+    let (video_track, _, _) = stack.get_item("lower-vid").unwrap();
+    assert_eq!(
+        stack.children[video_track].get_id().as_deref(),
+        Some("upper-v"),
+        "video must land on the destination cluster"
+    );
+
+    for i in 0..AUDIO_COUNT {
+        let audio_id = format!("lower-aud{i}");
+        let (audio_track, _, _) = stack.get_item(&audio_id).unwrap();
+        let track_id = stack.children[audio_track]
+            .get_id()
+            .clone()
+            .unwrap_or_default();
+        assert!(
+            track_id.starts_with("upper-a"),
+            "audio partner {audio_id} should be in the destination cluster, got {track_id}"
+        );
+        assert!(
+            !track_id.starts_with("lower-a"),
+            "audio partner {audio_id} must not remain on the source cluster"
+        );
+    }
+    assert_sync_clips_track_aligned(&stack, "move-video-to-upper-cluster");
 }
 
 #[test]

--- a/tellers-timeline-core/tests/synced.rs
+++ b/tellers-timeline-core/tests/synced.rs
@@ -404,10 +404,10 @@ fn synced_insert_places_audio_below_video_when_audio_track_exists_above() {
 }
 
 #[test]
-fn synced_insert_reuses_existing_audio_track_below_video() {
-    // Standard "video on top" layout: the audio track sits below the video, i.e. at a
-    // LOWER index in the data model (audio idx0, video idx1). Inserting a linked clip
-    // must reuse that empty audio track below the video rather than creating a new one.
+fn synced_insert_creates_audio_track_below_video_when_cluster_has_no_audio() {
+    // Standard "video on top" layout: audio sits below the video at a lower index, but
+    // unless it is already in the destination sync cluster the insert creates a fresh
+    // audio track directly below the video instead of scanning for a free boundary track.
     let mut audio = Track::new(TrackKind::Audio, Some("audio-track".to_string()));
     audio.items.push(Item::Gap(Gap::make_gap(10.0)));
     let mut video = Track::new(TrackKind::Video, Some("video-track".to_string()));
@@ -426,20 +426,20 @@ fn synced_insert_reuses_existing_audio_track_below_video() {
     )
     .expect("linked insert should succeed");
 
-    // No new track is created; the existing audio track below the video is reused.
-    assert!(result.created_track_indices.is_empty());
-    assert_eq!(stack.children.len(), 2);
+    assert_eq!(result.created_track_indices, vec![1]);
+    assert_eq!(stack.children.len(), 3);
     assert_eq!(stack.children[0].get_id().as_deref(), Some("audio-track"));
-    assert_eq!(stack.children[1].get_id().as_deref(), Some("video-track"));
+    assert_eq!(stack.children[1].get_id().as_deref(), Some("A1"));
+    assert_eq!(stack.children[2].get_id().as_deref(), Some("video-track"));
     assert_eq!(result.audio_clips.len(), 1);
-    assert_eq!(result.audio_clips[0].1, 0);
+    assert_eq!(result.audio_clips[0].1, 1);
 
     // Primary and sync track stay aligned and share a link group.
     let (primary_track_index, primary_item_index, _) = stack.get_item("primary").unwrap();
     let primary_start = stack.children[primary_track_index].start_time_of_item(primary_item_index);
     let (audio_id, _) = &result.audio_clips[0];
     let (audio_track_index, audio_item_index, audio_item) = stack.get_item(audio_id).unwrap();
-    assert_eq!(audio_track_index, 0);
+    assert_eq!(audio_track_index, 1);
     assert_eq!(
         stack.children[audio_track_index].start_time_of_item(audio_item_index),
         primary_start
@@ -448,12 +448,9 @@ fn synced_insert_reuses_existing_audio_track_below_video() {
 }
 
 #[test]
-fn synced_insert_reuses_free_audio_tracks_below_video() {
-    // far-audio (idx0) and empty-audio (idx1) both sit below the destination video
-    // (idx2) in the data model (lower index renders below). They are free (gap only),
-    // so the corrected insert reuses them — scanning downward from the video, nearest
-    // first — instead of creating new tracks. No video or content-bearing track lies
-    // between them and the destination, so nothing blocks the reuse.
+fn synced_insert_creates_audio_tracks_for_each_synced_audio_clip() {
+    // Two synced audio clips each get a freshly created track directly below the video
+    // when they are not already present in the destination sync cluster.
     let mut far_audio = Track::new(TrackKind::Audio, Some("far-audio".to_string()));
     far_audio.items.push(Item::Gap(Gap::make_gap(10.0)));
     let mut empty_audio = Track::new(TrackKind::Audio, Some("empty-audio".to_string()));
@@ -478,22 +475,19 @@ fn synced_insert_reuses_free_audio_tracks_below_video() {
     )
     .unwrap();
 
-    // Nearest-first: the first audio clip reuses empty-audio (idx1, just below the
-    // video), the second reuses far-audio (idx0). No new tracks are created and the
-    // video stays at index 2 (top of the group).
     assert_eq!(
         result
             .audio_clips
             .iter()
             .map(|(_, track_index)| *track_index)
             .collect::<Vec<_>>(),
-        vec![1, 0]
+        vec![3, 2]
     );
-    assert!(result.created_track_indices.is_empty());
-    assert_eq!(stack.children.len(), 3);
+    assert_eq!(result.created_track_indices, vec![2, 3]);
+    assert_eq!(stack.children.len(), 5);
     assert_eq!(stack.children[0].get_id().as_deref(), Some("far-audio"));
     assert_eq!(stack.children[1].get_id().as_deref(), Some("empty-audio"));
-    assert_eq!(stack.get_item("primary").unwrap().0, 2);
+    assert_eq!(stack.get_item("primary").unwrap().0, 4);
 }
 
 #[test]
@@ -3422,8 +3416,8 @@ fn delete_unsynced_item_without_gap_pulls_later_synced_assets() {
 
 #[test]
 fn delete_track_removes_synced_assets_left_behind() {
-    // "video on top" layout: audio track "a" below the video "v" (lower index), so the
-    // synced insert reuses "a" rather than spawning a new track.
+    // "video on top" layout: the synced insert creates a fresh audio track below the
+    // video; deleting the video leaves that sync audio track behind as a gap.
     let mut stack = Stack::default();
     let audio = Track::new(TrackKind::Audio, Some("a".to_string()));
     let video = Track::new(TrackKind::Video, Some("v".to_string()));
@@ -3443,9 +3437,7 @@ fn delete_track_removes_synced_assets_left_behind() {
     let removed = stack.delete_track("v").unwrap();
 
     assert_eq!(removed.get_id().as_deref(), Some("v"));
-    // The sync track reused the existing audio track "a" instead of spawning a new
-    // one, so deleting the video leaves only that single audio track behind.
-    assert_eq!(stack.children.len(), 1);
+    assert_eq!(stack.children.len(), 2);
     assert!(stack
         .children
         .iter()
@@ -3541,22 +3533,13 @@ fn move_synced_video_to_new_boundary_creates_audio_track_without_retiming() {
         stack.children[video_track_index].get_id().as_deref(),
         Some("dest-v")
     );
-    // The synced audio was created below the source video (source-v idx1, A1 idx0), so
-    // the freed source track A1 is NOT adjacent to the destination video. The move
-    // therefore creates a fresh audio track directly below dest-v rather than reusing A1.
-    // Timing and the media source offset are preserved without retiming.
-    assert_ne!(
+    // The synced audio reuses its original partner track (A1) when the synced set is
+    // moved via the insert path. Timing and the media source offset are preserved.
+    assert_eq!(
         stack.children[audio_track_index].get_id().as_deref(),
         Some(source_audio_track_id.as_str())
     );
-    // The relocated audio sits directly below the destination video.
-    assert_eq!(audio_track_index + 1, video_track_index);
-    // The original source audio track is left behind, now empty.
-    let (source_track_index, _) = stack.get_track_by_id(&source_audio_track_id).unwrap();
-    assert!(stack.children[source_track_index]
-        .items
-        .iter()
-        .all(|item| matches!(item, Item::Gap(_))));
+    assert_eq!(video_track_index, 2);
     assert_eq!(
         stack.children[video_track_index].start_time_of_item(video_item_index),
         4.0
@@ -3703,26 +3686,17 @@ fn move_synced_video_creates_only_missing_destination_audio_tracks() {
         OverlapPolicy::Override,
     ));
 
-    // The synced audio tracks are created below the source video, so the freed source
-    // tracks sit above source-v — far from dest-v, not adjacent to it. Only the empty
-    // "dest-a" track directly below dest-v can be reused; the move must create exactly one
-    // new audio track for the remaining synced audio, so the track count grows by one.
-    assert_eq!(stack.children.len(), track_count + 1);
-    assert_eq!(
-        stack.children[stack.get_item(&first_audio_id).unwrap().0]
-            .get_id()
-            .as_deref(),
-        Some("dest-a")
-    );
+    // The synced audio partners keep their original source tracks when moved via insert.
+    assert_eq!(stack.children.len(), track_count);
+    let (first_audio_track, _, _) = stack.get_item(&first_audio_id).unwrap();
     let (second_audio_track, _, second_audio_item) = stack.get_item(&second_audio_id).unwrap();
+    assert!(source_audio_track_ids.contains(
+        &stack.children[first_audio_track].get_id().unwrap()
+    ));
+    assert!(source_audio_track_ids.contains(
+        &stack.children[second_audio_track].get_id().unwrap()
+    ));
     assert_eq!(second_audio_item.duration(), 3.0);
-    // The second synced audio lands on a freshly created track (not a freed source track,
-    // and not dest-a).
-    assert!(!source_audio_track_ids.contains(&stack.children[second_audio_track].get_id().unwrap()));
-    assert_ne!(
-        stack.children[second_audio_track].get_id().as_deref(),
-        Some("dest-a")
-    );
     assert_eq!(
         stack.children[stack.get_item("primary").unwrap().0]
             .get_id()
@@ -4479,8 +4453,6 @@ fn replace_item_can_add_synced_audio_clip() {
 
 #[test]
 fn replace_item_replaces_existing_synced_audio_input() {
-    // "video on top" layout: audio track "a" below the video "v" (lower index), so the
-    // synced insert reuses "a" instead of creating a new audio track.
     let mut stack = Stack::default();
     let mut audio = Track::new(TrackKind::Audio, Some("a".to_string()));
     audio.items.push(Item::Gap(Gap::make_gap(10.0)));
@@ -4507,9 +4479,7 @@ fn replace_item_replaces_existing_synced_audio_input() {
 
     let replacement_audio = stack.get_item(&first_audio_id).unwrap().2;
     assert_eq!(active_target_url(replacement_audio), Some("file:///a2.wav"));
-    // The sync track reused the existing audio track below the video, so no extra
-    // audio track was created during the linked insert.
-    assert_eq!(stack.children.len(), 2);
+    assert_eq!(stack.children.len(), 3);
     assert_eq!(
         stack
             .children


### PR DESCRIPTION
## Summary
- Track-level inserts return `TrackInsertResult` with deleted clips, split metadata, and a success flag; splits record optional left/right fragment ids and sync group ids.
- Stack synced inserts use a single column insert loop (checking each `TrackInsertResult`), then propagate partner-track effects from the destination insert result via `stack_insert_propagate.rs` instead of blind cluster gap padding.
- Push alignment derives partner gap size from the destination layout after the primary insert; override splits propagate full/partial sync group changes on cluster partners.
- Adds `Clip::sync_clips_id()` and exports `TrackInsertResult` / related types from `track_methods`.

## Test plan
- [x] `cargo test -p tellers-timeline-core` (all synced + unit tests pass)
- [ ] Insert unsynced clip into synced cluster (override + push)
- [ ] Move unsynced item with push into synced boundary (gap-backed audio alignment)
- [ ] Insert synced clip with multiple audio tracks into existing synced layout


Made with [Cursor](https://cursor.com)