### PR TITLE
feat(core): add Track::set_volume

### DIFF
--- a/tellers-timeline-core/src/types.rs
+++ b/tellers-timeline-core/src/types.rs
@@ -1680,6 +1680,17 @@ impl Track {
             .filter_map(crate::metadata::IdMetadataExt::get_id)
             .collect()
     }
+
+    /// Set the volume on every item in the track.
+    ///
+    /// A track has no single volume field, so "track volume" is applied by
+    /// setting the given `volume` on each of its items (see
+    /// [`Item::set_volume`]).
+    pub fn set_volume(&mut self, volume: f64) {
+        for item in &mut self.items {
+            item.set_volume(volume);
+        }
+    }
 }
 
 impl Stack {

--- a/tellers-timeline-core/tests/volume.rs
+++ b/tellers-timeline-core/tests/volume.rs
@@ -1,0 +1,37 @@
+use tellers_timeline_core::Track;
+
+fn clip_json() -> &'static str {
+    r#"{
+        "OTIO_SCHEMA": "Clip.2",
+        "source_range": {
+            "OTIO_SCHEMA": "TimeRange.1",
+            "start_time": { "OTIO_SCHEMA": "RationalTime.1", "rate": 1, "value": 0 },
+            "duration": { "OTIO_SCHEMA": "RationalTime.1", "rate": 1, "value": 2 }
+        }
+    }"#
+}
+
+#[test]
+fn track_set_volume_applies_to_every_clip() {
+    let track_json = format!(
+        r#"{{
+            "OTIO_SCHEMA": "Track.1",
+            "kind": "Audio",
+            "children": [{c}, {c}]
+        }}"#,
+        c = clip_json(),
+    );
+    let mut track: Track = serde_json::from_str(&track_json).unwrap();
+
+    // Clips start at the default volume.
+    for item in &track.items {
+        assert_eq!(item.get_volume(), 1.0);
+    }
+
+    track.set_volume(0.25);
+
+    // Every item now reflects the track volume.
+    for item in &track.items {
+        assert_eq!(item.get_volume(), 0.25);
+    }
+}


### PR DESCRIPTION
## What

Adds a dedicated **`Track::set_volume(volume: f64)`** to `tellers-timeline-core`.

A `Track` has no single volume field, so it applies the given volume to **every item in the track** (via the existing `Item::set_volume`). Previously callers looped the items themselves — e.g. the timeline handle's `commit_set_track_volume` and the backend's `set_timeline_track_volume_json` both open-code `for item in &mut track.items { item.set_volume(volume) }`. This gives them one method to call.

```rust
pub fn set_volume(&mut self, volume: f64) {
    for item in &mut self.items {
        item.set_volume(volume);
    }
}
```

## Test

`tests/volume.rs` — build an audio track with two clips, `track.set_volume(0.25)`, assert every item's `get_volume()` returns `0.25`.

## Verification

- `cargo test -p tellers-timeline-core` — all suites pass (incl. the new `volume` test).
- Additive only (new method + test); no schema change (not a serialized field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)