### PR TITLE
feat(core): add Stack::clear_asset_backed_target_urls (selective, stack-level)

### DIFF
--- a/tellers-timeline-core/src/types.rs
+++ b/tellers-timeline-core/src/types.rs
@@ -1332,6 +1332,29 @@ impl MediaReference {
         }
     }
 
+    /// Clear the `target_url` only when this external reference is asset-backed,
+    /// i.e. its metadata carries a non-empty `tellers.ai.media_id`.
+    ///
+    /// Leaves a genuine non-asset external URL (no `media_id`) intact, and is a
+    /// no-op for generator references.
+    pub fn clear_asset_backed_target_url(&mut self) {
+        if let MediaReference::ExternalReference {
+            target_url,
+            metadata,
+            ..
+        } = self
+        {
+            let is_asset_backed = metadata
+                .get("tellers.ai")
+                .and_then(|v| v.get("media_id"))
+                .and_then(|v| v.as_str())
+                .is_some_and(|media_id| !media_id.is_empty());
+            if is_asset_backed && !target_url.is_empty() {
+                target_url.clear();
+            }
+        }
+    }
+
     pub fn generator_kind(&self) -> Option<&String> {
         match self {
             MediaReference::ExternalReference { .. } => None,
@@ -1690,5 +1713,21 @@ impl Stack {
             }
         }
         None
+    }
+
+    /// Clear presigned `target_url`s on asset-backed external references across
+    /// the whole stack (every track's clips). Non-asset external URLs (no
+    /// `tellers.ai.media_id`) are left intact. See
+    /// [`MediaReference::clear_asset_backed_target_url`].
+    pub fn clear_asset_backed_target_urls(&mut self) {
+        for track in &mut self.children {
+            for item in &mut track.items {
+                if let Item::Clip(clip) = item {
+                    for reference in clip.media_references.values_mut() {
+                        reference.clear_asset_backed_target_url();
+                    }
+                }
+            }
+        }
     }
 }

--- a/tellers-timeline-core/tests/clear_asset_backed.rs
+++ b/tellers-timeline-core/tests/clear_asset_backed.rs
@@ -1,0 +1,47 @@
+use tellers_timeline_core::Stack;
+
+fn clip(url: &str, media_id: Option<&str>) -> String {
+    let refs = match media_id {
+        Some(id) => format!(
+            r#"{{ "OTIO_SCHEMA": "ExternalReference.1", "target_url": "{url}",
+                  "metadata": {{ "tellers.ai": {{ "media_id": "{id}" }} }} }}"#
+        ),
+        None => format!(r#"{{ "OTIO_SCHEMA": "ExternalReference.1", "target_url": "{url}" }}"#),
+    };
+    format!(
+        r#"{{
+            "OTIO_SCHEMA": "Clip.2",
+            "active_media_reference_key": "DEFAULT_MEDIA",
+            "media_references": {{ "DEFAULT_MEDIA": {refs} }},
+            "source_range": {{
+                "OTIO_SCHEMA": "TimeRange.1",
+                "start_time": {{ "OTIO_SCHEMA": "RationalTime.1", "rate": 1, "value": 0 }},
+                "duration": {{ "OTIO_SCHEMA": "RationalTime.1", "rate": 1, "value": 2 }}
+            }}
+        }}"#
+    )
+}
+
+#[test]
+fn stack_clear_asset_backed_only_clears_refs_with_media_id() {
+    let stack_json = format!(
+        r#"{{
+            "OTIO_SCHEMA": "Stack.1",
+            "children": [{{
+                "OTIO_SCHEMA": "Track.1",
+                "kind": "Video",
+                "children": [{asset}, {raw}]
+            }}]
+        }}"#,
+        asset = clip("https://asset.example/a", Some("m1")),
+        raw = clip("https://raw.example/b", None),
+    );
+    let mut stack: Stack = serde_json::from_str(&stack_json).unwrap();
+
+    stack.clear_asset_backed_target_urls();
+
+    let json = serde_json::to_string(&stack).unwrap();
+    // Asset-backed URL cleared; genuine non-asset URL preserved.
+    assert!(!json.contains("asset.example"));
+    assert!(json.contains("raw.example"));
+}


### PR DESCRIPTION
## What

Adds a **selective, stack-level** clear of presigned `target_url`s to `tellers-timeline-core`:

- **`MediaReference::clear_asset_backed_target_url`** — clears `target_url` only when the external reference is **asset-backed** (its metadata carries a non-empty `tellers.ai.media_id`). A genuine non-asset external URL (no `media_id`) is left intact; no-op for generator references.
- **`Stack::clear_asset_backed_target_urls`** — applies it across every track's clips.

Complements #56's blunt `clear_target_urls` (which strips *all* `target_url`s at the Item/Track level). The app's persistence path needs the *asset-backed-only* variant — and at the **Stack** level rather than per-track, so it operates on a whole timeline's tracks in one call.

## Test

`tests/clear_asset_backed.rs` — a stack with one asset-backed clip (`media_id`) and one plain external-URL clip; after `clear_asset_backed_target_urls()`, the asset-backed URL is gone and the non-asset URL is preserved.

## Verification

- `cargo test -p tellers-timeline-core` passes (incl. the new test).
- Additive only; no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)