### PR TITLE
feat(core): add Clip/Item::get_rich_text + Track::average_volume

### DIFF
--- a/tellers-timeline-core/src/types.rs
+++ b/tellers-timeline-core/src/types.rs
@@ -329,6 +329,14 @@ impl Item {
             Item::Gap(_g) => 1.0,
         }
     }
+    /// The Rich Text Title HTML of this item's active media reference, if any.
+    /// None for gaps and non-rich-text clips.
+    pub fn get_rich_text(&self) -> Option<String> {
+        match self {
+            Item::Clip(c) => c.get_rich_text(),
+            Item::Gap(_g) => None,
+        }
+    }
     pub fn set_volume(&mut self, volume: f64) {
         if let Item::Clip(c) = self {
             c.set_volume(volume);
@@ -367,6 +375,16 @@ pub struct Clip {
 }
 
 impl Clip {
+    /// The Rich Text Title HTML of this clip's active media reference, if it is
+    /// a Rich generator reference. Mirrors the app's `extractTitleBlobHtml`.
+    pub fn get_rich_text(&self) -> Option<String> {
+        let key = self
+            .active_media_reference_key
+            .as_deref()
+            .unwrap_or("DEFAULT_MEDIA");
+        self.media_references.get(key)?.get_rich_text()
+    }
+
     pub fn bind_default_media_reference_when_needed(&mut self) {
         if self
             .active_media_reference_key
@@ -1679,6 +1697,24 @@ impl Track {
             .iter()
             .filter_map(crate::metadata::IdMetadataExt::get_id)
             .collect()
+    }
+
+    /// The mean volume across the track's clips (gaps ignored). Returns 0.0 when
+    /// the track has no clips. Mirrors the app's `Track.averageVolume`.
+    pub fn average_volume(&self) -> f64 {
+        let mut sum = 0.0;
+        let mut count = 0usize;
+        for item in &self.items {
+            if let Item::Clip(_) = item {
+                sum += item.get_volume();
+                count += 1;
+            }
+        }
+        if count == 0 {
+            0.0
+        } else {
+            sum / count as f64
+        }
     }
 
     /// Set the volume on every item in the track.

--- a/tellers-timeline-core/tests/clip_rich_text_and_avg_volume.rs
+++ b/tellers-timeline-core/tests/clip_rich_text_and_avg_volume.rs
@@ -1,0 +1,64 @@
+use tellers_timeline_core::{Clip, Track};
+
+const RICH_TEXT_REF: &str = r##"{
+    "OTIO_SCHEMA": "GeneratorReference.1",
+    "generator_kind": "Rich",
+    "parameters": {
+        "Resolve_OTIO": [
+            {
+                "Effect Name": "Rich Text",
+                "Enabled": true,
+                "Name": "Rich Text",
+                "Parameters": [
+                    { "Parameter ID": "title blob", "Title HTML": "<p>Hi</p>" }
+                ],
+                "Type": 24
+            }
+        ]
+    }
+}"##;
+
+fn source_range() -> &'static str {
+    r#"{ "OTIO_SCHEMA": "TimeRange.1",
+         "start_time": { "OTIO_SCHEMA": "RationalTime.1", "rate": 1, "value": 0 },
+         "duration": { "OTIO_SCHEMA": "RationalTime.1", "rate": 1, "value": 2 } }"#
+}
+
+#[test]
+fn clip_get_rich_text_reads_active_reference_title() {
+    let clip_json = format!(
+        r#"{{
+            "OTIO_SCHEMA": "Clip.2",
+            "active_media_reference_key": "DEFAULT_MEDIA",
+            "media_references": {{ "DEFAULT_MEDIA": {rich} }},
+            "source_range": {sr}
+        }}"#,
+        rich = RICH_TEXT_REF,
+        sr = source_range(),
+    );
+    let clip: Clip = serde_json::from_str(&clip_json).unwrap();
+    assert_eq!(clip.get_rich_text(), Some("<p>Hi</p>".to_string()));
+}
+
+#[test]
+fn track_average_volume_means_clip_volumes_ignoring_gaps() {
+    let track_json = format!(
+        r#"{{
+            "OTIO_SCHEMA": "Track.1",
+            "kind": "Audio",
+            "children": [
+                {{ "OTIO_SCHEMA": "Clip.2", "source_range": {sr} }},
+                {{ "OTIO_SCHEMA": "Clip.2", "source_range": {sr} }},
+                {{ "OTIO_SCHEMA": "Gap.1", "source_range": {sr} }}
+            ]
+        }}"#,
+        sr = source_range(),
+    );
+    let mut track: Track = serde_json::from_str(&track_json).unwrap();
+
+    // Two clips at the default volume (1.0); the gap is ignored.
+    assert_eq!(track.average_volume(), 1.0);
+
+    track.set_volume(0.5);
+    assert_eq!(track.average_volume(), 0.5);
+}


### PR DESCRIPTION
## What

Moves two OTIO reads out of the app (`otio_extension.dart`) into the core:

- **`Clip::get_rich_text`** / **`Item::get_rich_text`** — the clip's active-media-reference Rich Text Title HTML, mirroring the app's `extractTitleBlobHtml`. It resolves the active reference (defaulting to `DEFAULT_MEDIA`) and defers to the existing `MediaReference::get_rich_text`.
- **`Track::average_volume`** — the mean volume across the track's clips (gaps ignored; 0.0 when empty), mirroring the app's `Track.averageVolume`.

Both are pure reads the app currently does in Dart; having them in the core lets the app call them (via the timeline handle) and drop the corresponding `otio_extension` logic as part of removing the Dart OTIO types.

## Tests

`tests/clip_rich_text_and_avg_volume.rs`:
- `clip_get_rich_text_reads_active_reference_title` — a clip whose active ref is a Rich generator returns its title HTML.
- `track_average_volume_means_clip_volumes_ignoring_gaps` — two default-volume clips + a gap → 1.0; after `set_volume(0.5)` → 0.5.

## Verification

- `cargo test -p tellers-timeline-core` passes (incl. the new tests).
- Additive only; no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)