### PR TITLE
feat(core): public group-id accessors + Gap OTIO_SCHEMA dispatch

### DIFF
--- a/tellers-timeline-core/src/metadata.rs
+++ b/tellers-timeline-core/src/metadata.rs
@@ -210,3 +210,88 @@ impl MetadataExt for Item {
         }
     }
 }
+
+// ---- Group-id metadata accessors -------------------------------------------
+//
+// Timeline items carry two distinct grouping ids in their metadata:
+//
+// * the Resolve "Link Group ID" (`metadata["Resolve_OTIO"]["Link Group ID"]`),
+//   which ties synchronised clips together, and
+// * the Tellers Group ID (`metadata["tellers.ai"]["Tellers Group ID"]`), the
+//   Tellers-native "move together" grouping.
+//
+// These accessors expose the read/write conventions for both so callers (the
+// editor bridge, the stack methods) don't re-implement the metadata layout.
+
+/// The Resolve "Link Group ID" of an item (the sync-clip group), or `None` for
+/// an ungrouped clip or a gap.
+pub fn item_link_group_id(item: &Item) -> Option<i64> {
+    match item {
+        Item::Clip(clip) => clip.sync_clips_id(),
+        Item::Gap(_) => None,
+    }
+}
+
+/// The Tellers Group ID of an item, or `None` for an ungrouped clip or a gap.
+pub fn item_tellers_group_id(item: &Item) -> Option<i64> {
+    match item {
+        Item::Clip(clip) => resolve_tellers_group_id(&clip.metadata),
+        Item::Gap(_) => None,
+    }
+}
+
+/// Set (or clear, when `group_id` is `None`) the Tellers Group ID on an item.
+pub fn set_item_tellers_group_id(item: &mut Item, group_id: Option<i64>) {
+    let metadata = item.get_metadata_mut();
+    match group_id {
+        Some(group_id) => set_tellers_group_id(metadata, group_id),
+        None => {
+            remove_tellers_group_id(metadata);
+        }
+    }
+}
+
+/// Read the Tellers group id from `metadata["tellers.ai"]["Tellers Group ID"]`.
+///
+/// This is the Tellers-native grouping concept, kept separate from the Resolve
+/// "Link Group ID" (sync clips) and stored in the Tellers metadata namespace
+/// alongside `timeline_id`. An int, uint, or stringified value all read back.
+pub fn resolve_tellers_group_id(metadata: &serde_json::Value) -> Option<i64> {
+    let raw = metadata
+        .get("tellers.ai")
+        .and_then(|v| v.get("Tellers Group ID"))?;
+    raw.as_i64()
+        .or_else(|| raw.as_u64().and_then(|value| i64::try_from(value).ok()))
+        .or_else(|| raw.as_str().and_then(|value| value.parse::<i64>().ok()))
+}
+
+/// Write `group_id` to `metadata["tellers.ai"]["Tellers Group ID"]`, creating
+/// the `tellers.ai` object if it is missing or not an object.
+pub fn set_tellers_group_id(metadata: &mut serde_json::Value, group_id: i64) {
+    if metadata.as_object().is_none() {
+        *metadata = serde_json::Value::Object(serde_json::Map::new());
+    }
+    let map = metadata.as_object_mut().unwrap();
+    let ai = map
+        .entry("tellers.ai".to_string())
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+    if ai.as_object().is_none() {
+        *ai = serde_json::Value::Object(serde_json::Map::new());
+    }
+    ai.as_object_mut().unwrap().insert(
+        "Tellers Group ID".to_string(),
+        serde_json::Value::Number(serde_json::Number::from(group_id)),
+    );
+}
+
+/// Remove the Tellers Group ID from `metadata`, returning whether one was
+/// present.
+pub fn remove_tellers_group_id(metadata: &mut serde_json::Value) -> bool {
+    let Some(ai) = metadata
+        .get_mut("tellers.ai")
+        .and_then(|value| value.as_object_mut())
+    else {
+        return false;
+    };
+    ai.remove("Tellers Group ID").is_some()
+}

--- a/tellers-timeline-core/src/stack_methods/mod.rs
+++ b/tellers-timeline-core/src/stack_methods/mod.rs
@@ -1,3 +1,4 @@
+use crate::metadata::{item_link_group_id, item_tellers_group_id, resolve_tellers_group_id};
 use crate::{
     Clip, Gap, IdMetadataExt, InsertPolicy, Item, OverlapPolicy, Seconds, Stack, Track, TrackKind,
     TrackInsertResult,
@@ -3829,67 +3830,12 @@ fn resolve_sync_clips_id(metadata: &serde_json::Value) -> Option<i64> {
     Clip::resolve_otio_i64(metadata, "Link Group ID")
 }
 
-fn item_link_group_id(item: &Item) -> Option<i64> {
-    match item {
-        Item::Clip(clip) => clip.sync_clips_id(),
-        Item::Gap(_) => None,
-    }
-}
-
-fn item_tellers_group_id(item: &Item) -> Option<i64> {
-    match item {
-        Item::Clip(clip) => resolve_tellers_group_id(&clip.metadata),
-        Item::Gap(_) => None,
-    }
-}
-
 /// Identifies a movable sub-unit within a Tellers group: either a whole sync
 /// column (shared Link Group ID) or a single unsynced clip (by timeline id).
 #[derive(PartialEq, Eq, Hash, Clone)]
 enum SubUnitKey {
     Sync(i64),
     Clip(String),
-}
-
-/// Read the Tellers group id from `metadata["tellers.ai"]["Tellers Group ID"]`.
-///
-/// This is the Tellers-native grouping concept, kept separate from the
-/// Resolve "Link Group ID" (sync clips) and stored in the Tellers metadata
-/// namespace alongside `timeline_id`.
-pub(super) fn resolve_tellers_group_id(metadata: &serde_json::Value) -> Option<i64> {
-    let raw = metadata
-        .get("tellers.ai")
-        .and_then(|v| v.get("Tellers Group ID"))?;
-    raw.as_i64()
-        .or_else(|| raw.as_u64().and_then(|value| i64::try_from(value).ok()))
-        .or_else(|| raw.as_str().and_then(|value| value.parse::<i64>().ok()))
-}
-
-pub(super) fn set_tellers_group_id(metadata: &mut serde_json::Value, group_id: i64) {
-    if metadata.as_object().is_none() {
-        *metadata = serde_json::Value::Object(serde_json::Map::new());
-    }
-    let map = metadata.as_object_mut().unwrap();
-    let ai = map
-        .entry("tellers.ai".to_string())
-        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
-    if ai.as_object().is_none() {
-        *ai = serde_json::Value::Object(serde_json::Map::new());
-    }
-    ai.as_object_mut().unwrap().insert(
-        "Tellers Group ID".to_string(),
-        serde_json::Value::Number(serde_json::Number::from(group_id)),
-    );
-}
-
-pub(super) fn remove_tellers_group_id(metadata: &mut serde_json::Value) -> bool {
-    let Some(ai) = metadata
-        .get_mut("tellers.ai")
-        .and_then(|value| value.as_object_mut())
-    else {
-        return false;
-    };
-    ai.remove("Tellers Group ID").is_some()
 }
 
 pub(super) fn set_resolve_sync_clips_id(metadata: &mut serde_json::Value, sync_clips_id: i64) {

--- a/tellers-timeline-core/src/stack_methods/stack_item_link.rs
+++ b/tellers-timeline-core/src/stack_methods/stack_item_link.rs
@@ -77,7 +77,7 @@ impl Stack {
             else {
                 continue;
             };
-            super::set_tellers_group_id(&mut clip.metadata, group_id);
+            crate::set_tellers_group_id(&mut clip.metadata, group_id);
         }
         Some(group_id)
     }
@@ -93,7 +93,7 @@ impl Stack {
                 continue;
             };
             if let Item::Clip(clip) = &self.children[track_index].items[item_index] {
-                if let Some(group_id) = super::resolve_tellers_group_id(&clip.metadata) {
+                if let Some(group_id) = crate::resolve_tellers_group_id(&clip.metadata) {
                     group_ids.insert(group_id);
                 }
             }
@@ -109,7 +109,7 @@ impl Stack {
                 else {
                     continue;
                 };
-                if super::remove_tellers_group_id(&mut clip.metadata) {
+                if crate::remove_tellers_group_id(&mut clip.metadata) {
                     count += 1;
                 }
             }

--- a/tellers-timeline-core/src/types.rs
+++ b/tellers-timeline-core/src/types.rs
@@ -207,11 +207,40 @@ where
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq)]
 #[serde(untagged)]
 pub enum Item {
     Clip(Clip),
     Gap(Gap),
+}
+
+impl<'de> Deserialize<'de> for Item {
+    /// Dispatch on `OTIO_SCHEMA`: a `Gap.*` schema deserializes as [`Gap`],
+    /// everything else as [`Clip`].
+    ///
+    /// A plain `#[serde(untagged)]` deserialize would always match [`Clip`]
+    /// first — every `Clip` field but `source_range` is `#[serde(default)]`, so
+    /// a gap object parses cleanly as a `Clip` and the `Gap` variant is never
+    /// reached. Dispatching on the schema keeps gaps as gaps on the way in.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let is_gap = value
+            .get("OTIO_SCHEMA")
+            .and_then(|schema| schema.as_str())
+            .is_some_and(|schema| {
+                schema.eq_ignore_ascii_case("Gap.1") || schema.eq_ignore_ascii_case("Gap")
+            });
+        if is_gap {
+            Gap::deserialize(value).map(Item::Gap).map_err(D::Error::custom)
+        } else {
+            Clip::deserialize(value)
+                .map(Item::Clip)
+                .map_err(D::Error::custom)
+        }
+    }
 }
 
 // No longer used; OTIO-only shape is parsed directly above

--- a/tellers-timeline-core/tests/gap_deserialization.rs
+++ b/tellers-timeline-core/tests/gap_deserialization.rs
@@ -1,0 +1,78 @@
+// `Item` dispatches on `OTIO_SCHEMA` when deserializing: a `Gap.*` object must
+// land on `Item::Gap`, not be swallowed by the (untagged, listed-first) `Clip`
+// variant. Without the custom deserializer every gap parses as an empty clip.
+
+use tellers_timeline_core::{Item, Stack, Timeline};
+
+const GAP_JSON: &str = r#"{
+    "OTIO_SCHEMA": "Gap.1",
+    "metadata": { "tellers.ai": { "timeline_id": "gap-1" } },
+    "source_range": {
+        "OTIO_SCHEMA": "TimeRange.1",
+        "start_time": { "OTIO_SCHEMA": "RationalTime.1", "rate": 1, "value": 0 },
+        "duration": { "OTIO_SCHEMA": "RationalTime.1", "rate": 1, "value": 3 }
+    }
+}"#;
+
+const CLIP_JSON: &str = r#"{
+    "OTIO_SCHEMA": "Clip.2",
+    "metadata": { "tellers.ai": { "timeline_id": "clip-1" } },
+    "source_range": {
+        "OTIO_SCHEMA": "TimeRange.1",
+        "start_time": { "OTIO_SCHEMA": "RationalTime.1", "rate": 1, "value": 0 },
+        "duration": { "OTIO_SCHEMA": "RationalTime.1", "rate": 1, "value": 5 }
+    }
+}"#;
+
+#[test]
+fn gap_schema_deserializes_as_gap() {
+    let item: Item = serde_json::from_str(GAP_JSON).expect("gap parses");
+    assert!(matches!(item, Item::Gap(_)), "Gap.1 must parse as Item::Gap");
+    assert_eq!(item.duration(), 3.0);
+}
+
+#[test]
+fn clip_schema_still_deserializes_as_clip() {
+    let item: Item = serde_json::from_str(CLIP_JSON).expect("clip parses");
+    assert!(matches!(item, Item::Clip(_)));
+}
+
+#[test]
+fn gap_round_trips_through_serialize() {
+    let item: Item = serde_json::from_str(GAP_JSON).unwrap();
+    let json = serde_json::to_string(&item).unwrap();
+    let reparsed: Item = serde_json::from_str(&json).unwrap();
+    assert!(matches!(reparsed, Item::Gap(_)));
+    assert_eq!(item, reparsed);
+}
+
+#[test]
+fn gaps_survive_a_timeline_round_trip() {
+    // A gap embedded in a track keeps its Gap identity through parse + reserialize.
+    let timeline_json = format!(
+        r#"{{
+            "OTIO_SCHEMA": "Timeline.1",
+            "tracks": {{
+                "OTIO_SCHEMA": "Stack.1",
+                "children": [{{
+                    "OTIO_SCHEMA": "Track.1",
+                    "kind": "Video",
+                    "children": [{CLIP_JSON}, {GAP_JSON}]
+                }}]
+            }}
+        }}"#
+    );
+    let timeline: Timeline = serde_json::from_str(&timeline_json).expect("timeline parses");
+    let track = &timeline.tracks.children[0];
+    assert!(matches!(track.items[0], Item::Clip(_)));
+    assert!(matches!(track.items[1], Item::Gap(_)));
+
+    let out = serde_json::to_string(&timeline).unwrap();
+    let reparsed: Timeline = serde_json::from_str(&out).unwrap();
+    assert!(matches!(reparsed.tracks.children[0].items[1], Item::Gap(_)));
+
+    // And a bare Stack round-trips its gaps too (the editor seeds from Stack JSON).
+    let stack_json = serde_json::to_string(&timeline.tracks).unwrap();
+    let stack: Stack = serde_json::from_str(&stack_json).unwrap();
+    assert!(matches!(stack.children[0].items[1], Item::Gap(_)));
+}

--- a/tellers-timeline-core/tests/group_id_metadata.rs
+++ b/tellers-timeline-core/tests/group_id_metadata.rs
@@ -1,0 +1,105 @@
+// Tests for the public group-id metadata accessors (`item_link_group_id`,
+// `item_tellers_group_id`, `set_item_tellers_group_id`, and the underlying
+// `resolve/set/remove_tellers_group_id` helpers). These read/write the
+// `tellers.ai` and `Resolve_OTIO` metadata namespaces and are consumed by the
+// flutter_rust_bridge editor layer, so they are part of the public surface.
+
+use tellers_timeline_core::{
+    item_link_group_id, item_tellers_group_id, remove_tellers_group_id, resolve_tellers_group_id,
+    set_item_tellers_group_id, set_tellers_group_id, Clip, Gap, Item, MediaReference, RationalTime,
+    TimeRange,
+};
+
+fn range(duration: f64) -> TimeRange {
+    TimeRange {
+        otio_schema: "TimeRange.1".to_string(),
+        start_time: RationalTime {
+            otio_schema: "RationalTime.1".to_string(),
+            rate: 1.0,
+            value: 0.0,
+        },
+        duration: RationalTime {
+            otio_schema: "RationalTime.1".to_string(),
+            rate: 1.0,
+            value: duration,
+        },
+    }
+}
+
+fn media_ref() -> MediaReference {
+    MediaReference::ExternalReference {
+        target_url: "file:///video.mov".to_string(),
+        available_range: Some(range(100.0)),
+        name: None,
+        available_image_bounds: Some(serde_json::Value::Null),
+        metadata: serde_json::json!({}),
+    }
+}
+
+fn clip(id: &str) -> Item {
+    Item::Clip(Clip::new_single_media_reference(
+        range(5.0),
+        media_ref(),
+        None,
+        Some(id.to_string()),
+    ))
+}
+
+fn gap() -> Item {
+    Item::Gap(Gap {
+        otio_schema: "Gap.1".to_string(),
+        name: None,
+        source_range: range(2.0),
+        metadata: serde_json::json!({}),
+        effects: Vec::new(),
+    })
+}
+
+#[test]
+fn tellers_group_id_round_trips_and_clears() {
+    let mut item = clip("clip-1");
+    assert_eq!(item_tellers_group_id(&item), None);
+
+    set_item_tellers_group_id(&mut item, Some(42));
+    assert_eq!(item_tellers_group_id(&item), Some(42));
+
+    set_item_tellers_group_id(&mut item, None);
+    assert_eq!(item_tellers_group_id(&item), None);
+}
+
+#[test]
+fn tellers_group_id_coerces_uint_and_string() {
+    let mut item = clip("clip-1");
+    // A stringified id (as Resolve/legacy data can carry) still reads back.
+    if let Item::Clip(c) = &mut item {
+        c.metadata = serde_json::json!({ "tellers.ai": { "Tellers Group ID": "7" } });
+    }
+    assert_eq!(item_tellers_group_id(&item), Some(7));
+}
+
+#[test]
+fn link_group_id_reads_resolve_otio_and_ignores_gaps() {
+    let mut item = clip("clip-1");
+    if let Item::Clip(c) = &mut item {
+        c.metadata = serde_json::json!({ "Resolve_OTIO": { "Link Group ID": 9 } });
+    }
+    assert_eq!(item_link_group_id(&item), Some(9));
+
+    // Gaps never carry a group id.
+    assert_eq!(item_link_group_id(&gap()), None);
+    assert_eq!(item_tellers_group_id(&gap()), None);
+}
+
+#[test]
+fn metadata_level_helpers_operate_on_raw_value() {
+    let mut metadata = serde_json::json!({});
+    assert_eq!(resolve_tellers_group_id(&metadata), None);
+
+    set_tellers_group_id(&mut metadata, 3);
+    assert_eq!(resolve_tellers_group_id(&metadata), Some(3));
+
+    assert!(remove_tellers_group_id(&mut metadata));
+    assert_eq!(resolve_tellers_group_id(&metadata), None);
+    // Removing again reports nothing was present.
+    assert!(!remove_tellers_group_id(&mut metadata));
+}


### PR DESCRIPTION
Two related changes that let the `tellers-app` flutter_rust_bridge layer stop re-implementing / normalizing metadata and structure this crate owns.

## 1. Expose group-id metadata accessors as public API

The FRB layer re-implemented the Resolve **Link Group ID** and Tellers **Group ID** accessors that already existed *privately* here. Promoted the canonical versions to public API in `metadata.rs`:

- `item_link_group_id(&Item)` / `item_tellers_group_id(&Item)`
- `set_item_tellers_group_id(&mut Item, Option<i64>)`
- `resolve_tellers_group_id` / `set_tellers_group_id` / `remove_tellers_group_id` (metadata-level, relocated from `stack_methods`)

`stack_methods` now imports these instead of defining its own copies. No behavior change (verbatim moves). Adds `tests/group_id_metadata.rs`.

## 2. Deserialize `Gap.*` items as `Item::Gap`

`Item` was `#[serde(untagged)]` with `Clip` listed first, and every `Clip` field but `source_range` is `#[serde(default)]` — so a gap object parsed cleanly as an empty `Clip` and the `Gap` variant was **unreachable**. Consumers had to run a normalization pass to turn `Gap.1`-shaped clips back into gaps.

Replaced the untagged deserialize with a custom impl dispatching on `OTIO_SCHEMA` (`Gap.*` → `Gap`, else `Clip`). Serialization is unchanged (still transparent). Adds `tests/gap_deserialization.rs`.

## Verification

Full suite green (269 tests: 265 pre-existing + the two new files). `cargo build`, `cargo fmt --check` (my files), `cargo test` all pass.

## Companion PR

`tellers-app` (undisclosed-team/tellers-app#2965): deletes its duplicate accessors **and** its now-unnecessary gap + `resolve`→`Resolve_OTIO` normalization passes, pinning this crate to the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)