### PR TITLE
fix(core): accept OTIO MissingReference as an empty external reference

### DIFF
--- a/tellers-timeline-core/src/types.rs
+++ b/tellers-timeline-core/src/types.rs
@@ -1302,9 +1302,26 @@ fn clamp_crop_inset(value: f64) -> f64 {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(tag = "OTIO_SCHEMA")]
 pub enum MediaReference {
-    #[serde(rename = "ExternalReference.1")]
+    /// OTIO's `MissingReference` is accepted as an alias and read as an
+    /// external reference with an empty `target_url`.
+    ///
+    /// Producers outside our control emit it: the OTIO AAF adapter answers
+    /// every SourceMob that records no locator URL with a `MissingReference`,
+    /// so importing an Avid sequence used to fail here — `unknown variant
+    /// MissingReference.1` — and take down the whole project load, even for
+    /// clips whose media we had resolved.
+    ///
+    /// It is an alias rather than a third variant because "no media yet" is
+    /// already what an empty `target_url` means throughout the pipeline
+    /// (`clear_target_urls` empties the field on every project we serve), and
+    /// because a distinct variant would force a meaning at each of the
+    /// matches on this enum for no behavioural gain. It re-serializes as
+    /// `ExternalReference.1`.
+    #[serde(rename = "ExternalReference.1", alias = "MissingReference.1")]
     ExternalReference {
-        #[serde(rename = "target_url")]
+        // Defaulted so a `MissingReference`, which carries no such field,
+        // lands as the empty target url that means "nothing to play yet".
+        #[serde(rename = "target_url", default)]
         target_url: String,
         #[serde(default)]
         available_range: Option<TimeRange>,

--- a/tellers-timeline-core/tests/missing_reference.rs
+++ b/tellers-timeline-core/tests/missing_reference.rs
@@ -128,3 +128,17 @@ fn a_genuinely_unknown_reference_schema_is_still_rejected() {
         "only MissingReference is aliased; anything else should still fail loudly"
     );
 }
+
+#[test]
+fn image_sequence_reference_is_still_rejected() {
+    // OTIO registers four MediaReference subclasses — ExternalReference,
+    // GeneratorReference, MissingReference and ImageSequenceReference — and
+    // this enum models two of them. An OTIO file using an image sequence
+    // therefore still fails to load, the same way MissingReference did.
+    // Recorded so the gap is visible rather than discovered in the app.
+    let json = timeline_json("ImageSequenceReference.1", "");
+
+    let result: Result<Timeline, _> = serde_json::from_str(&json);
+
+    assert!(result.is_err());
+}

--- a/tellers-timeline-core/tests/missing_reference.rs
+++ b/tellers-timeline-core/tests/missing_reference.rs
@@ -1,0 +1,130 @@
+//! OTIO's `MissingReference` is accepted as an external reference with no
+//! `target_url`.
+//!
+//! The OTIO AAF adapter answers every SourceMob that records no locator URL
+//! with a `MissingReference`, so an imported Avid sequence used to fail the
+//! whole project load with `unknown variant MissingReference.1` — including
+//! for clips whose media had been resolved, since the schema tag has nothing
+//! to do with whether we found the asset.
+
+use tellers_timeline_core::{Item, MediaReference, Timeline};
+
+/// A one-clip timeline whose only media reference uses `schema`, shaped like
+/// what the AAF adapter emits.
+fn timeline_json(schema: &str, extra_fields: &str) -> String {
+    format!(
+        r#"{{
+            "OTIO_SCHEMA": "Timeline.1",
+            "name": "SEQ",
+            "tracks": {{
+                "OTIO_SCHEMA": "Stack.1",
+                "name": "tracks",
+                "children": [{{
+                    "OTIO_SCHEMA": "Track.1",
+                    "name": "V1",
+                    "kind": "Video",
+                    "children": [{{
+                        "OTIO_SCHEMA": "Clip.2",
+                        "name": "A001C001",
+                        "active_media_reference_key": "DEFAULT_MEDIA",
+                        "media_references": {{
+                            "DEFAULT_MEDIA": {{
+                                "OTIO_SCHEMA": "{schema}",
+                                "name": "A001C001",
+                                {extra_fields}
+                                "metadata": {{ "media_id": "asset-1" }}
+                            }}
+                        }},
+                        "source_range": {{
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "start_time": {{
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 25.0, "value": 0.0
+                            }},
+                            "duration": {{
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 25.0, "value": 100.0
+                            }}
+                        }}
+                    }}]
+                }}]
+            }}
+        }}"#
+    )
+}
+
+fn only_reference(timeline: &Timeline) -> &MediaReference {
+    let track = &timeline.tracks.children[0];
+    let Item::Clip(clip) = &track.items[0] else {
+        panic!("expected a clip");
+    };
+    clip.media_references
+        .values()
+        .next()
+        .expect("clip keeps its media reference")
+}
+
+#[test]
+fn missing_reference_parses_as_an_empty_external_reference() {
+    let json = timeline_json("MissingReference.1", "");
+
+    let timeline: Timeline = serde_json::from_str(&json).expect("MissingReference is accepted");
+
+    match only_reference(&timeline) {
+        MediaReference::ExternalReference { target_url, .. } => {
+            assert_eq!(target_url, "", "no media to point at yet");
+        }
+        other => panic!("expected an external reference, got {other:?}"),
+    }
+}
+
+#[test]
+fn missing_reference_keeps_the_metadata_that_links_it_to_an_asset() {
+    // The whole point of keeping the clip: the media_id survives, so a
+    // resolved clip is still linked even when the AAF recorded no path.
+    let json = timeline_json("MissingReference.1", "");
+
+    let timeline: Timeline = serde_json::from_str(&json).unwrap();
+
+    let MediaReference::ExternalReference { metadata, .. } = only_reference(&timeline) else {
+        panic!("expected an external reference");
+    };
+    assert_eq!(metadata["media_id"], "asset-1");
+}
+
+#[test]
+fn missing_reference_re_serializes_as_an_external_reference() {
+    let json = timeline_json("MissingReference.1", "");
+    let timeline: Timeline = serde_json::from_str(&json).unwrap();
+
+    let out = serde_json::to_string(&timeline).unwrap();
+
+    assert!(out.contains("ExternalReference.1"));
+    assert!(!out.contains("MissingReference.1"));
+}
+
+#[test]
+fn an_ordinary_external_reference_is_untouched() {
+    let json = timeline_json("ExternalReference.1", r#""target_url": "s3://bucket/a.mxf","#);
+
+    let timeline: Timeline = serde_json::from_str(&json).unwrap();
+
+    match only_reference(&timeline) {
+        MediaReference::ExternalReference { target_url, .. } => {
+            assert_eq!(target_url, "s3://bucket/a.mxf");
+        }
+        other => panic!("expected an external reference, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_genuinely_unknown_reference_schema_is_still_rejected() {
+    let json = timeline_json("SomeFutureReference.1", "");
+
+    let result: Result<Timeline, _> = serde_json::from_str(&json);
+
+    assert!(
+        result.is_err(),
+        "only MissingReference is aliased; anything else should still fail loudly"
+    );
+}


### PR DESCRIPTION
## The failure

The OTIO AAF adapter answers **every SourceMob that records no locator URL** with a `MissingReference`. Deserializing a timeline containing one fails:

```
unknown variant `MissingReference.1`, expected `ExternalReference.1` or `GeneratorReference.1`
```

In the app's WASM build that surfaces as `PanicException(EXECUTE_SYNC_ABORT RuntimeError: unreachable)` — it takes down the running session rather than failing one project load. It was hit importing an Avid sequence (undisclosed-team/tellers-app#3102).

Two details worth knowing, because they make this broader than "missing media":

- **It fires on clips whose media we resolved.** The schema tag reflects what the AAF recorded, not whether Tellers found the asset. A fully-linked sequence still fails if the AAF carried no file paths.
- **The Python binding fails differently and more quietly**: it parses such a clip with *no* media references at all, dropping the `media_id` that links it to its asset. So the backend cannot catch this — it silently produces a project with broken media links.

## The change

`MissingReference.1` becomes an **alias** on `ExternalReference`, not a third variant, and `target_url` is defaulted so the aliased form — which carries no such field — lands empty.

An alias rather than a variant because:

- "No media yet" is already what an empty `target_url` means throughout the pipeline — `clear_target_urls` empties that field on every project we serve, so an empty one is an ordinary state.
- A third variant would force a semantic decision at each of the ~14 exhaustive matches on this enum for no behavioural gain, and would change `PyMediaReference`'s public surface.

It re-serializes as `ExternalReference.1`, so stored timelines stay canonical.

**Only that one schema is aliased.** An unknown reference schema still fails loudly — there's a test pinning that, so this isn't a blanket loosening of the parser.

## Testing

`cargo test -p tellers-timeline-core -p tellers-timeline-schema` — 278 passing, 0 failures. Five new tests: the alias parses, the `media_id` metadata survives, it re-serializes as `ExternalReference.1`, an ordinary external reference is untouched, and an unknown schema is still rejected.

## Notes for the reviewer

- **`spec/otio.schema.json` is deliberately not regenerated here.** Running `just regen-schema` produces a ~636-line diff, almost all of it unrelated drift — the committed file has not been regenerated since #25. Nothing in CI checks it. That looked like its own cleanup rather than something to bundle into a bug fix; happy to do it separately if you'd rather.
- `cargo fmt --check` reports 378 pre-existing diffs repo-wide (including in `bindings/python/src/lib.rs`, untouched here). My own region adds none; I did not reformat anything.
- Consumers need a repin to pick this up: `tellers-app` pins `tellers-timeline-core` at `9a4773b4`, and `tellers-backend` pins the Python binding at `fc300f7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)